### PR TITLE
Add the JSONP Flavor

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/export/Flavor.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Flavor.java
@@ -39,6 +39,11 @@ public enum Flavor {
             return new JSONDataWriter(w,config);
         }
     },
+    JSONP("application/javascript;charset=UTF-8") {
+        public DataWriter createDataWriter(Object bean, Writer w, ExportConfig config) throws IOException {
+            return new JSONDataWriter(w,config);
+        }
+    },
     PYTHON("text/x-python;charset=UTF-8") {
         public DataWriter createDataWriter(Object bean, Writer w, ExportConfig config) throws IOException {
             return new PythonDataWriter(w,config);


### PR DESCRIPTION
add the JSONP flavour for avoid:
Refused to execute script from 'TARGET URL' because its MIME type ('application/json') is not executable, and strict MIME type checking is enabled