### PR TITLE
[FIXED JENKINS-27256] Dispatcher for getX(long) model object methods

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/TokenList.java
+++ b/core/src/main/java/org/kohsuke/stapler/TokenList.java
@@ -86,14 +86,14 @@ public final class TokenList {
         return tokens[--idx];
     }
     public int nextAsInt() throws NumberFormatException {
-        long l = nextAsLong();
-        if (l < Integer.MIN_VALUE) {
-            throw new NumberFormatException(String.format("Token '%d' cannot be interpreted as an integer as its value is less than %d.", l, Integer.MIN_VALUE));
-        } else if (l > Integer.MAX_VALUE) {
-            throw new NumberFormatException(String.format("Token '%d' cannot be interpreted as an integer as its value is greater than %d.", l, Integer.MAX_VALUE));
+        long asLongValue = nextAsLong();
+        if (asLongValue < Integer.MIN_VALUE) {
+            throw new NumberFormatException(String.format("Token '%d' cannot be interpreted as an integer as its value is less than %d.", asLongValue, Integer.MIN_VALUE));
+        } else if (asLongValue > Integer.MAX_VALUE) {
+            throw new NumberFormatException(String.format("Token '%d' cannot be interpreted as an integer as its value is greater than %d.", asLongValue, Integer.MAX_VALUE));
         }
 
-        return (int) l;
+        return (int) asLongValue;
     }
     public long nextAsLong() throws NumberFormatException {
         String p = peek();

--- a/core/src/main/java/org/kohsuke/stapler/TokenList.java
+++ b/core/src/main/java/org/kohsuke/stapler/TokenList.java
@@ -87,9 +87,12 @@ public final class TokenList {
     }
     public int nextAsInt() throws NumberFormatException {
         long l = nextAsLong();
-        if (l > Integer.MAX_VALUE) {
-            throw new NumberFormatException(String.format("Token '%d' cannot be interpreted as an integer as it's value is greater than %d.", l, Integer.MAX_VALUE));
+        if (l < Integer.MIN_VALUE) {
+            throw new NumberFormatException(String.format("Token '%d' cannot be interpreted as an integer as its value is less than %d.", l, Integer.MIN_VALUE));
+        } else if (l > Integer.MAX_VALUE) {
+            throw new NumberFormatException(String.format("Token '%d' cannot be interpreted as an integer as its value is greater than %d.", l, Integer.MAX_VALUE));
         }
+
         return (int) l;
     }
     public long nextAsLong() throws NumberFormatException {

--- a/core/src/main/java/org/kohsuke/stapler/TokenList.java
+++ b/core/src/main/java/org/kohsuke/stapler/TokenList.java
@@ -86,12 +86,20 @@ public final class TokenList {
         return tokens[--idx];
     }
     public int nextAsInt() throws NumberFormatException {
+        long l = nextAsLong();
+        if (l > Integer.MAX_VALUE) {
+            throw new NumberFormatException(String.format("Token '%d' cannot be interpreted as an integer as it's value is greater than %d.", l, Integer.MAX_VALUE));
+        }
+        return (int) l;
+    }
+    public long nextAsLong() throws NumberFormatException {
         String p = peek();
-        if(p==null)
+        if(p == null) {
             throw new NumberFormatException();  // no more token
-        int i = Integer.valueOf(p);
+        }
+        long l = Long.valueOf(p);
         idx++;
-        return i;
+        return l;
     }
 
     public int length() {

--- a/core/src/main/java/org/kohsuke/stapler/TokenList.java
+++ b/core/src/main/java/org/kohsuke/stapler/TokenList.java
@@ -100,9 +100,9 @@ public final class TokenList {
         if(p == null) {
             throw new NumberFormatException();  // no more token
         }
-        long l = Long.valueOf(p);
+        long asLongValue = Long.valueOf(p);
         idx++;
-        return l;
+        return asLongValue;
     }
 
     public int length() {


### PR DESCRIPTION
See [JENKINS-27256](https://issues.jenkins-ci.org/browse/JENKINS-27256).

Added dispatcher for `getX(long)` style model methods. Already tested manually but will add a functional test in Jenkins core test harness (yeah, should have done that first etc etc).

@reviewbybees