### PR TITLE
[JENKINS-27918] Downgrade stapler-class warning to FINE

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
@@ -70,7 +70,7 @@ import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.logging.Logger;
 
-import static java.util.logging.Level.WARNING;
+import static java.util.logging.Level.*;
 import static javax.servlet.http.HttpServletResponse.*;
 
 /**
@@ -576,7 +576,7 @@ public class RequestImpl extends HttpServletRequestWrapper implements StaplerReq
                         if(j.has("stapler-class")) {
                             // deprecated as of 2.4-jenkins-4 but left here for a while until we are sure nobody uses this
                             className = j.getString("stapler-class");
-                            LOGGER.log(WARNING, "'stapler-class' is deprecated: "+className);
+                            LOGGER.log(FINE, "stapler-class is deprecated in favor of $class: {0}", className);
                         }
                         if(j.has("$class")) {
                             className = j.getString("$class");


### PR DESCRIPTION
[JENKINS-27918](https://issues.jenkins-ci.org/browse/JENKINS-27918)

It is confusing and annoying to repeatedly print a warning to the log when Jenkins core still produces `stapler-class` (despite https://github.com/jenkinsci/jenkins/pull/1443) and there is nothing a user or plugin developer can do about it. Was suggested that this be downgraded in https://github.com/stapler/stapler/commit/82b0a45924b083796d04c94661bbef7b80e2d2bf which introduced this warning.

Cf. #39 and https://github.com/jenkinsci/jenkins/pull/1563.

@reviewbybees