### PR TITLE
Use stapler.tmpPath to set upload tmp dir

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
@@ -862,7 +862,14 @@ public class RequestImpl extends HttpServletRequestWrapper implements StaplerReq
         if(parsedFormData!=null)    return;
 
         parsedFormData = new HashMap<String,FileItem>();
-        ServletFileUpload upload = new ServletFileUpload(new DiskFileItemFactory());
+        DiskFileItemFactory factory = null;
+        String path = System.getProperty("stapler.tmpPath");
+        if (path != null) {
+            factory = new DiskFileItemFactory(DiskFileItemFactory.DEFAULT_SIZE_THRESHOLD, new File(path));
+        } else {
+            factory = new DiskFileItemFactory();
+        }
+        ServletFileUpload upload = new ServletFileUpload(factory);
         try {
             for( FileItem fi : (List<FileItem>)upload.parseRequest(this) )
                 parsedFormData.put(fi.getFieldName(),fi);


### PR DESCRIPTION
From https://groups.google.com/forum/#!topic/jenkinsci-dev/aNeXlUqS0R8

At the moment, the only way to set the tmp dir for uploads in Stapler is via `java.io.tmpdir`. Apache Commons FileUpload, used by Stapler, lets you define a different directory for that. 

Following the example from MetaClassLoader, this pull request adds another variable used by stapler for that: `stapler.tmpPath`. Tested locally with Jenkins and Stapler in Eclipse workspace. All tests passed.

Thank you