### PR TITLE
Indicate implementation class in REST API

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/export/Model.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Model.java
@@ -190,6 +190,9 @@ public class Model<T> {
                 superBlacklist.add(p.name);
             }
             superModel.writeNestedObjectTo(object, pruner, writer, superBlacklist);
+        } else {
+            writer.name("class");
+            writer.value(object.getClass().getSimpleName());
         }
 
         for (Property p : properties) {

--- a/core/src/main/java/org/kohsuke/stapler/export/Model.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Model.java
@@ -192,7 +192,7 @@ public class Model<T> {
             superModel.writeNestedObjectTo(object, pruner, writer, superBlacklist);
         } else {
             writer.name("$class");
-            writer.value(object.getClass().getSimpleName());
+            writer.value(object.getClass().getName());
         }
 
         for (Property p : properties) {

--- a/core/src/main/java/org/kohsuke/stapler/export/Model.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Model.java
@@ -149,7 +149,7 @@ public class Model<T> {
     /**
      * Writes the property values of the given object to the writer.
      */
-    public void writeTo(T object, DataWriter writer) throws IOException {
+    public void writeTo(@CheckForNull T object, DataWriter writer) throws IOException {
         writeTo(object,0,writer);
     }
 
@@ -159,7 +159,7 @@ public class Model<T> {
      * @param pruner
      *      Controls which portion of the object graph will be sent to the writer.
      */
-    public void writeTo(T object, TreePruner pruner, DataWriter writer) throws IOException {
+    public void writeTo(@CheckForNull T object, TreePruner pruner, DataWriter writer) throws IOException {
         writer.startObject();
         writeNestedObjectTo(object, pruner, writer, Collections.<String>emptySet());
         writer.endObject();
@@ -179,11 +179,11 @@ public class Model<T> {
      *
      * @deprecated as of 1.139
      */
-    public void writeTo(T object, int baseVisibility, DataWriter writer) throws IOException {
+    public void writeTo(@CheckForNull T object, int baseVisibility, DataWriter writer) throws IOException {
         writeTo(object,new ByDepth(1-baseVisibility),writer);
     }
 
-    void writeNestedObjectTo(T object, TreePruner pruner, DataWriter writer, Set<? extends String> blacklist) throws IOException {
+    void writeNestedObjectTo(@CheckForNull T object, TreePruner pruner, DataWriter writer, Set<? extends String> blacklist) throws IOException {
         if (superModel != null) {
             Set<String> superBlacklist = new HashSet<String>(blacklist);
             for (Property p : properties) {
@@ -191,8 +191,10 @@ public class Model<T> {
             }
             superModel.writeNestedObjectTo(object, pruner, writer, superBlacklist);
         } else {
-            writer.name("$class");
-            writer.value(object.getClass().getName());
+            if (object != null) {
+                writer.name("$class");
+                writer.value(object.getClass().getName());
+            }
         }
 
         for (Property p : properties) {

--- a/core/src/main/java/org/kohsuke/stapler/export/Model.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Model.java
@@ -191,7 +191,7 @@ public class Model<T> {
             }
             superModel.writeNestedObjectTo(object, pruner, writer, superBlacklist);
         } else {
-            writer.name("class");
+            writer.name("$class");
             writer.value(object.getClass().getSimpleName());
         }
 

--- a/core/src/main/java/org/kohsuke/stapler/export/SchemaGenerator.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/SchemaGenerator.java
@@ -104,6 +104,7 @@ public class SchemaGenerator {
             cm = ct.complexContent().extension().base(getXmlTypeName(m.superModel.type)).sequence();
         }
 
+        cm.element().name("class").type(XSD.Types.STRING);
         for (Property p : m.getProperties()) {
             Class t = p.getType();
             final boolean isCollection;

--- a/core/src/test/java/org/kohsuke/stapler/export/JSONDataWriterTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/JSONDataWriterTest.java
@@ -1,0 +1,57 @@
+package org.kohsuke.stapler.export;
+
+import junit.framework.TestCase;
+
+import java.io.IOException;
+import java.io.StringWriter;
+
+public class JSONDataWriterTest extends TestCase {
+
+    public JSONDataWriterTest(String n) {
+        super(n);
+    }
+
+    private static <T> String serialize(T bean, Class<T> clazz) throws IOException {
+        StringWriter w = new StringWriter();
+        Model<T> model = new ModelBuilder().get(clazz);
+        model.writeTo(bean, Flavor.JSON.createDataWriter(bean, w));
+        return w.toString();
+    }
+
+    @ExportedBean public static class X {
+        @Exported public String a = "aval";
+        public String b = "bval";
+        @Exported public String getC() {return "cval";}
+        public String getD() {return "dval";}
+    }
+
+    public void testSimpleUsage() throws Exception {
+        assertEquals("{\"class\":\"X\",\"a\":\"aval\",\"c\":\"cval\"}",
+                serialize(new X(), X.class));
+    }
+
+    @ExportedBean(defaultVisibility=2) public static abstract class Super {
+        @Exported public String basic = "super";
+        @Exported public abstract String generic();
+    }
+    public static class Sub extends Super {
+        public String generic() {return "sub";}
+        @Exported public String specific() {return "sub";}
+    }
+    @ExportedBean public static class Container {
+        @Exported public Super polymorph = new Sub();
+    }
+
+    public void testInheritance() throws Exception {
+        assertEquals("{\"class\":\"Container\",\"polymorph\":{\"class\":\"Sub\",\"basic\":\"super\",\"generic\":\"sub\",\"specific\":\"sub\"}}",
+                serialize(new Container(), Container.class));
+    }
+
+    public static class Sub2 extends Super {
+        @Exported @Override public String generic() {return "sub2";}
+    }
+    public void testInheritance2() throws Exception { // JENKINS-13336
+        assertEquals("{\"class\":\"Sub2\",\"basic\":\"super\",\"generic\":\"sub2\"}",
+                serialize(new Sub2(), Sub2.class));
+    }
+}

--- a/core/src/test/java/org/kohsuke/stapler/export/JSONDataWriterTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/JSONDataWriterTest.java
@@ -1,16 +1,13 @@
 package org.kohsuke.stapler.export;
 
-import junit.framework.TestCase;
+import org.junit.Test;
 
 import java.io.IOException;
 import java.io.StringWriter;
 
-public class JSONDataWriterTest extends TestCase {
+import static org.junit.Assert.assertEquals;
 
-    public JSONDataWriterTest(String n) {
-        super(n);
-    }
-
+public class JSONDataWriterTest {
     private static <T> String serialize(T bean, Class<T> clazz) throws IOException {
         StringWriter w = new StringWriter();
         Model<T> model = new ModelBuilder().get(clazz);
@@ -25,6 +22,7 @@ public class JSONDataWriterTest extends TestCase {
         public String getD() {return "dval";}
     }
 
+    @Test
     public void testSimpleUsage() throws Exception {
         assertEquals("{\"class\":\"X\",\"a\":\"aval\",\"c\":\"cval\"}",
                 serialize(new X(), X.class));
@@ -42,6 +40,7 @@ public class JSONDataWriterTest extends TestCase {
         @Exported public Super polymorph = new Sub();
     }
 
+    @Test
     public void testInheritance() throws Exception {
         assertEquals("{\"class\":\"Container\",\"polymorph\":{\"class\":\"Sub\",\"basic\":\"super\",\"generic\":\"sub\",\"specific\":\"sub\"}}",
                 serialize(new Container(), Container.class));
@@ -50,6 +49,8 @@ public class JSONDataWriterTest extends TestCase {
     public static class Sub2 extends Super {
         @Exported @Override public String generic() {return "sub2";}
     }
+
+    @Test
     public void testInheritance2() throws Exception { // JENKINS-13336
         assertEquals("{\"class\":\"Sub2\",\"basic\":\"super\",\"generic\":\"sub2\"}",
                 serialize(new Sub2(), Sub2.class));

--- a/core/src/test/java/org/kohsuke/stapler/export/NamedPathPrunerTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/NamedPathPrunerTest.java
@@ -42,11 +42,11 @@ public class NamedPathPrunerTest extends TestCase {
         Vhew view1 = new Vhew("All", "crap", new Jhob[] {job1, job2});
         Vhew view2 = new Vhew("Some", "less", new Jhob[] {job1});
         Stuff bean = new Stuff(new Jhob[] {job1, job2}, Arrays.asList(view1, view2));
-        assertResult("{jobs:[{displayName:Job #1,name:job1},{displayName:Job #2,name:job2}],"
-                + "views:[{jobs:[{name:job1},{name:job2}],name:All},{jobs:[{name:job1}],name:Some}]}",
+        assertResult("{class:Stuff,jobs:[{class:Jhob,displayName:Job #1,name:job1},{class:Jhob,displayName:Job #2,name:job2}],"
+                + "views:[{class:Vhew,jobs:[{class:Jhob,name:job1},{class:Jhob,name:job2}],name:All},{class:Vhew,jobs:[{class:Jhob,name:job1}],name:Some}]}",
                 bean, "jobs[name,displayName],views[name,jobs[name]]");
-        assertResult("{jobs:[{displayName:Job #1,name:job1}],views:[{jobs:[],name:All},"
-                + "{jobs:[],name:Some}]}",
+        assertResult("{class:Stuff,jobs:[{class:Jhob,displayName:Job #1,name:job1}],views:[{class:Vhew,jobs:[],name:All},"
+                + "{class:Vhew,jobs:[],name:Some}]}",
                 bean, "jobs[name,displayName]{,1},views[name,jobs[name]{,0}]");
     }
 
@@ -56,10 +56,10 @@ public class NamedPathPrunerTest extends TestCase {
             jobs[i] = new Jhob("job"+i,"aaa","bbb");
         Vhew v = new Vhew("view","aaa",jobs);
 
-        assertResult("{jobs:[{name:job0},{name:job1},{name:job2}]}",    v, "jobs[name]{,3}");
-        assertResult("{jobs:[{name:job3},{name:job4},{name:job5}]}",    v, "jobs[name]{3,6}");
-        assertResult("{jobs:[{name:job38}]}",                           v, "jobs[name]{38}");
-        assertResult("{jobs:[{name:job97},{name:job98},{name:job99}]}", v, "jobs[name]{97,}");
+        assertResult("{class:Vhew,jobs:[{class:Jhob,name:job0},{class:Jhob,name:job1},{class:Jhob,name:job2}]}",    v, "jobs[name]{,3}");
+        assertResult("{class:Vhew,jobs:[{class:Jhob,name:job3},{class:Jhob,name:job4},{class:Jhob,name:job5}]}",    v, "jobs[name]{3,6}");
+        assertResult("{class:Vhew,jobs:[{class:Jhob,name:job38}]}",                           v, "jobs[name]{38}");
+        assertResult("{class:Vhew,jobs:[{class:Jhob,name:job97},{class:Jhob,name:job98},{class:Jhob,name:job99}]}", v, "jobs[name]{97,}");
     }
     
     @ExportedBean public static class Stuff {

--- a/core/src/test/java/org/kohsuke/stapler/export/XMLDataWriterTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/XMLDataWriterTest.java
@@ -30,7 +30,7 @@ public class XMLDataWriterTest extends TestCase {
         public String getD() {return "dval";}
     }
     public void testSimpleUsage() throws Exception {
-        assertEquals("<x><a>aval</a><c>cval</c></x>",
+        assertEquals("<x><class>X</class><a>aval</a><c>cval</c></x>",
                 serialize(new X(), X.class));
     }
 
@@ -46,7 +46,7 @@ public class XMLDataWriterTest extends TestCase {
         @Exported public Super polymorph = new Sub();
     }
     public void testInheritance() throws Exception {
-        assertEquals("<container><polymorph><basic>super</basic><generic>sub</generic>" +
+        assertEquals("<container><class>Container</class><polymorph><class>Sub</class><basic>super</basic><generic>sub</generic>" +
                 "<specific>sub</specific></polymorph></container>",
                 serialize(new Container(), Container.class));
     }
@@ -55,7 +55,7 @@ public class XMLDataWriterTest extends TestCase {
         @Exported @Override public String generic() {return "sub2";}
     }
     public void testInheritance2() throws Exception { // JENKINS-13336
-        assertEquals("<sub2><basic>super</basic><generic>sub2</generic></sub2>",
+        assertEquals("<sub2><class>Sub2</class><basic>super</basic><generic>sub2</generic></sub2>",
                 serialize(new Sub2(), Sub2.class));
     }
 
@@ -77,7 +77,7 @@ public class XMLDataWriterTest extends TestCase {
     }
 
     public void testPrimitiveArrays() throws Exception {
-        assertEquals("<PA><v>1</v><v>2</v><v>3</v></PA>",serialize(new PA(),PA.class));
+        assertEquals("<PA><class>PA</class><v>1</v><v>2</v><v>3</v></PA>",serialize(new PA(),PA.class));
     }
 
     public void testMakeXmlName() {
@@ -93,7 +93,7 @@ public class XMLDataWriterTest extends TestCase {
     }
 
     public void testToSingular() throws Exception {
-        assertEquals("<arrays><category>general</category><category>specific</category><style>ornate</style><style>plain</style></arrays>",
+        assertEquals("<arrays><class>Arrays</class><category>general</category><category>specific</category><style>ornate</style><style>plain</style></arrays>",
                 serialize(new Arrays(), Arrays.class));
     }
 


### PR DESCRIPTION
When using the Rest API it is sometimes difficult to know the object that you are working with (Folder, Freestyle project, Maven project, etc.). This PR adds a `class` element which makes knowing the objects class that are being used by the rest api easier.

@reviewbybees @kohsuke 