### PR TITLE
Model may capture synthetic methods during export

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/export/Model.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Model.java
@@ -93,7 +93,7 @@ public class Model<T> {
         }
 
         for( Method m : type.getMethods() ) {
-            if(m.getDeclaringClass()!=type) continue;
+            if (m.getDeclaringClass() != type || m.isSynthetic()) continue;
             Exported exported = m.getAnnotation(Exported.class);
             if(exported !=null) {
                 if (m.getParameterTypes().length > 0) {


### PR DESCRIPTION
It all starts with the following test failure on Jenkins:

    wrappedMultipleItems(hudson.model.ApiTest)  Time elapsed: 15.874 sec  <<< FAILURE!
    org.junit.ComparisonFailure: expected:<...><name>test1</name><[]/root>> but was:<...><name>test1</name><[name>test0</name><name>test1</name><]/root>>
	at org.junit.Assert.assertEquals(Assert.java:115)
	at org.junit.Assert.assertEquals(Assert.java:144)
	at hudson.model.ApiTest.wrappedMultipleItems(ApiTest.java:100)

After looking through the Api class it became apparent that something must be going wrong during:

    p.writeTo(bean,pruner,Flavor.XML.createDataWriter(bean,sw));

This was printing the test0 and test1 jobs twice into StringWriter, so I've started to investigate the recursive logic of writeNestedObject and after a few iterations it turned out that the model itself is incorrectly generated: Jenkins had two MethodProperty with name "jobs", one was referencing a List&lt;TopLevelItem> getItems method, the other was referring to a Collection getItems method.

When debugging the model generation I could see both methods, but I could see that one method had modifier of 1 (public), whilst the other had 4161 (synthetic public volatile). Now I'm not that good at JVM internals, but I can only guess that this synthetic method is only there to make life easier for the JVM.

Anyways: the following little change appears to resolve the test failure in Jenkins. So far I could only see this test failing on OSX, so this test failure may be platform dependent, but I feel having this fix in place could simplify life for developers on OSX.