### PR TITLE
Make stapler JDK 9 ready

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -90,7 +90,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>annotation-indexer</artifactId>
-      <version>1.9</version>
+      <version>1.10</version>
       <optional>true</optional>
     </dependency>
     <dependency>

--- a/core/src/main/java/org/kohsuke/stapler/jsr269/ExportedBeanAnnotationProcessor.java
+++ b/core/src/main/java/org/kohsuke/stapler/jsr269/ExportedBeanAnnotationProcessor.java
@@ -146,6 +146,8 @@ public class ExportedBeanAnnotationProcessor extends AbstractProcessorImpl {
             in.close();
         } catch (FileNotFoundException e) {
             // no existing file, which is fine
+        } catch (java.nio.file.NoSuchFileException e) {
+            // no existing file, which is fine
         }
     }
 

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/ConstructorProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/ConstructorProcessorTest.java
@@ -20,7 +20,7 @@ public class ConstructorProcessorTest {
                 addLine("  @DataBoundConstructor public Stuff(int count, String name) {}").
                 addLine("}");
         compilation.doCompile(null, "-source", "6");
-        assertEquals(Collections.emptyList(), Utils.filterSupportedSourceVersionWarnings(compilation.getDiagnostics()));
+        assertEquals(Collections.emptyList(), Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics()));
         assertEquals("{constructor=count,name}", Utils.normalizeProperties(Utils.getGeneratedResource(compilation, "some/pkg/Stuff.stapler")));
     }
 
@@ -32,7 +32,7 @@ public class ConstructorProcessorTest {
                 addLine("  /** @stapler-constructor */ public Stuff(String name, int count) {}").
                 addLine("}");
         compilation.doCompile(null, "-source", "6");
-        assertEquals(Collections.emptyList(), Utils.filterSupportedSourceVersionWarnings(compilation.getDiagnostics()));
+        assertEquals(Collections.emptyList(), Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics()));
         assertEquals("{constructor=name,count}", Utils.normalizeProperties(Utils.getGeneratedResource(compilation, "some/pkg/Stuff.stapler")));
     }
 
@@ -47,7 +47,7 @@ public class ConstructorProcessorTest {
         compilation.addSource("some.pkg.package-info").
                 addLine("package some.pkg;");
         compilation.doCompile(null, "-source", "6");
-        assertEquals(Collections.emptyList(), Utils.filterSupportedSourceVersionWarnings(compilation.getDiagnostics()));
+        assertEquals(Collections.emptyList(), Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics()));
         assertEquals("{constructor=count,name}", Utils.normalizeProperties(Utils.getGeneratedResource(compilation, "some/pkg/Stuff.stapler")));
     }
 
@@ -60,7 +60,7 @@ public class ConstructorProcessorTest {
                 addLine("  @DataBoundConstructor Stuff() {}").
                 addLine("}");
         compilation.doCompile(null, "-source", "6");
-        List<Diagnostic<? extends JavaFileObject>> diagnostics = Utils.filterSupportedSourceVersionWarnings(compilation.getDiagnostics());
+        List<Diagnostic<? extends JavaFileObject>> diagnostics = Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics());
         assertEquals(1, diagnostics.size());
         String msg = diagnostics.get(0).getMessage(Locale.ENGLISH);
         assertTrue(msg, msg.contains("public"));
@@ -75,7 +75,7 @@ public class ConstructorProcessorTest {
                 addLine("  @DataBoundConstructor public Stuff() {}").
                 addLine("}");
         compilation.doCompile(null, "-source", "6");
-        List<Diagnostic<? extends JavaFileObject>> diagnostics = Utils.filterSupportedSourceVersionWarnings(compilation.getDiagnostics());
+        List<Diagnostic<? extends JavaFileObject>> diagnostics = Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics());
         assertEquals(1, diagnostics.size());
         String msg = diagnostics.get(0).getMessage(Locale.ENGLISH);
         assertTrue(msg, msg.contains("abstract"));

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/ExportedBeanAnnotationProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/ExportedBeanAnnotationProcessorTest.java
@@ -25,7 +25,7 @@ public class ExportedBeanAnnotationProcessorTest {
                 addLine("  @Exported(name=\"name\") public String getDisplayName() {return null;}").
                 addLine("}");
         compilation.doCompile(null, "-source", "6");
-        assertEquals(Collections.emptyList(), Utils.filterSupportedSourceVersionWarnings(compilation.getDiagnostics()));
+        assertEquals(Collections.emptyList(), Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics()));
         assertEqualsCRLF("some.pkg.Stuff\n", Utils.getGeneratedResource(compilation, "META-INF/annotations/org.kohsuke.stapler.export.ExportedBean"));
         assertEqualsCRLF("some.pkg.Stuff\n", Utils.getGeneratedResource(compilation, ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
         assertEquals("{getDisplayName=This gets the display name. }", Utils.normalizeProperties(Utils.getGeneratedResource(compilation, "some/pkg/Stuff.javadoc")));
@@ -40,7 +40,7 @@ public class ExportedBeanAnnotationProcessorTest {
                 addLine("  @Exported public int getCount() {return 0;}").
                 addLine("}");
         compilation.doCompile(null, "-source", "6");
-        assertEquals(Collections.emptyList(), Utils.filterSupportedSourceVersionWarnings(compilation.getDiagnostics()));
+        assertEquals(Collections.emptyList(), Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics()));
         assertEqualsCRLF("some.pkg.Stuff\n", Utils.getGeneratedResource(compilation, "META-INF/annotations/org.kohsuke.stapler.export.ExportedBean"));
         assertEqualsCRLF("some.pkg.Stuff\n", Utils.getGeneratedResource(compilation, ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
         // TODO should it be null, i.e. is it desired to create an empty *.javadoc file?
@@ -59,7 +59,7 @@ public class ExportedBeanAnnotationProcessorTest {
                 addLine("  @Override public int getCount() {return 0;}").
                 addLine("}");
         compilation.doCompile(null, "-source", "6");
-        assertEquals(Collections.emptyList(), Utils.filterSupportedSourceVersionWarnings(compilation.getDiagnostics()));
+        assertEquals(Collections.emptyList(), Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics()));
         /* #7188605: broken in JDK 6u33 + org.jvnet.hudson:annotation-indexer:1.2:
         assertEquals("some.pkg.Stuff\n", Utils.getGeneratedResource(compilation, "META-INF/annotations/org.kohsuke.stapler.export.ExportedBean"));
         */
@@ -78,7 +78,7 @@ public class ExportedBeanAnnotationProcessorTest {
                 addLine("  @Exported public int getCount() {return 0;}").
                 addLine("}");
         compilation.doCompile(null, "-source", "6");
-        assertEquals(Collections.emptyList(), Utils.filterSupportedSourceVersionWarnings(compilation.getDiagnostics()));
+        assertEquals(Collections.emptyList(), Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics()));
         assertEqualsCRLF("some.pkg.Stuff\n", Utils.getGeneratedResource(compilation, ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
         compilation = new Compilation(compilation);
         compilation.addSource("some.pkg.MoreStuff").
@@ -88,7 +88,7 @@ public class ExportedBeanAnnotationProcessorTest {
                 addLine("  @Exported public int getCount() {return 0;}").
                 addLine("}");
         compilation.doCompile(null, "-source", "6");
-        assertEquals(Collections.emptyList(), Utils.filterSupportedSourceVersionWarnings(compilation.getDiagnostics()));
+        assertEquals(Collections.emptyList(), Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics()));
         assertEqualsCRLF("some.pkg.MoreStuff\nsome.pkg.Stuff\n", Utils.getGeneratedResource(compilation, ExportedBeanAnnotationProcessor.STAPLER_BEAN_FILE));
     }
 

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/QueryParameterAnnotationProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/QueryParameterAnnotationProcessorTest.java
@@ -17,7 +17,7 @@ public class QueryParameterAnnotationProcessorTest {
                 addLine("  public void doAnother(@QueryParameter(\"ignoredHere\") String name, @QueryParameter String address) {}").
                 addLine("}");
         compilation.doCompile(null, "-source", "6");
-        assertEquals(Collections.emptyList(), Utils.filterSupportedSourceVersionWarnings(compilation.getDiagnostics()));
+        assertEquals(Collections.emptyList(), Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics()));
         assertEquals("key", Utils.getGeneratedResource(compilation, "some/pkg/Stuff/doOneThing.stapler"));
         assertEquals("name,address", Utils.getGeneratedResource(compilation, "some/pkg/Stuff/doAnother.stapler"));
     }

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/RequirePOSTAnnotationProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/RequirePOSTAnnotationProcessorTest.java
@@ -46,7 +46,7 @@ public class RequirePOSTAnnotationProcessorTest {
                 addLine("  @RequirePOST public void doSomething() {}").
                 addLine("}");
         compilation.doCompile(null, "-source", "6");
-        assertEquals(Collections.emptyList(), Utils.filterSupportedSourceVersionWarnings(compilation.getDiagnostics()));
+        assertEquals(Collections.emptyList(), Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics()));
     }
 
     @Test public void noAbstract() throws Exception {
@@ -58,7 +58,7 @@ public class RequirePOSTAnnotationProcessorTest {
                 addLine("  @RequirePOST public abstract void doSomething();").
                 addLine("}");
         compilation.doCompile(null, "-source", "6");
-        List<Diagnostic<? extends JavaFileObject>> diagnostics = Utils.filterSupportedSourceVersionWarnings(compilation.getDiagnostics());
+        List<Diagnostic<? extends JavaFileObject>> diagnostics = Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics());
         assertEquals(1, diagnostics.size());
         assertEquals(Diagnostic.Kind.ERROR, diagnostics.get(0).getKind());
         String msg = diagnostics.get(0).getMessage(Locale.ENGLISH);
@@ -79,7 +79,7 @@ public class RequirePOSTAnnotationProcessorTest {
                 addLine("  @Override public void doSomething() {}").
                 addLine("}");
         compilation.doCompile(null, "-source", "6");
-        List<Diagnostic<? extends JavaFileObject>> diagnostics = Utils.filterSupportedSourceVersionWarnings(compilation.getDiagnostics());
+        List<Diagnostic<? extends JavaFileObject>> diagnostics = Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics());
         assertEquals(1, diagnostics.size());
         assertEquals(Diagnostic.Kind.WARNING, diagnostics.get(0).getKind());
         assertEquals("some/pkg/SpecialStuff.java", diagnostics.get(0).getSource().toUri().toString());
@@ -102,7 +102,7 @@ public class RequirePOSTAnnotationProcessorTest {
                 addLine("  @RequirePOST  @Override public void doSomething() {}").
                 addLine("}");
         compilation.doCompile(null, "-source", "6");
-        assertEquals(Collections.emptyList(), Utils.filterSupportedSourceVersionWarnings(compilation.getDiagnostics()));
+        assertEquals(Collections.emptyList(), Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics()));
     }
 
 }

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/Utils.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/Utils.java
@@ -20,8 +20,6 @@ import net.java.dev.hickory.testing.Compilation;
 
 class Utils {
 
-    // Filter out warnings about source 1.6 is obsolete in java 9
-    // This usually appears with other warnings
     public static final List<String> IGNORE = Arrays.asList(
             "source value 1.6 is obsolete and will be removed in a future release", // Filter out warnings about source 1.6 is obsolete in java 9
             "To suppress warnings about obsolete options" // This usually appears with other warnings

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/WebMethodAnnotationProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/WebMethodAnnotationProcessorTest.java
@@ -46,7 +46,7 @@ public class WebMethodAnnotationProcessorTest {
                 addLine("  @WebMethod(name=\"hello\") public void doSomething() {}").
                 addLine("}");
         compilation.doCompile(null, "-source", "6");
-        assertEquals(Collections.emptyList(), compilation.getDiagnostics());
+        assertEquals(Collections.emptyList(), Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics()));
     }
 
     @Test public void nonDoMethods() throws Exception {
@@ -58,7 +58,7 @@ public class WebMethodAnnotationProcessorTest {
                 addLine("  @WebMethod(name=\"hello\") public void something() {}").
                 addLine("}");
         compilation.doCompile(null, "-source", "6");
-        List<Diagnostic<? extends JavaFileObject>> diagnostics = compilation.getDiagnostics();
+        List<Diagnostic<? extends JavaFileObject>> diagnostics = Utils.filterObsoleteSourceVersionWarnings(compilation.getDiagnostics());
         assertEquals(1, diagnostics.size());
         String msg = diagnostics.get(0).getMessage(Locale.ENGLISH);
         assertTrue(msg, msg.contains("something"));

--- a/jelly/pom.xml
+++ b/jelly/pom.xml
@@ -5,11 +5,11 @@
     <artifactId>stapler-parent</artifactId>
     <version>1.238-SNAPSHOT</version>
   </parent>
-  
+
   <artifactId>stapler-jelly</artifactId>
   <name>Stapler Jelly module</name>
   <description>Jelly binding for Stapler</description>
-  
+
   <dependencies>
     <dependency>
       <groupId>${project.groupId}</groupId>
@@ -107,11 +107,9 @@
         <version>1.2</version>
         <dependencies>
           <dependency>
-            <groupId>com.sun</groupId>
-            <artifactId>tools</artifactId>
-            <scope>system</scope>
-            <version>1.6</version>
-            <systemPath>${toolsjar}</systemPath>
+            <groupId>com.github.olivergondza</groupId>
+            <artifactId>maven-jdk-tools-wrapper</artifactId>
+            <version>0.1</version>
           </dependency>
         </dependencies>
       </plugin>
@@ -135,11 +133,9 @@
             </executions>
             <dependencies>
               <dependency>
-                <groupId>com.sun</groupId>
-                <artifactId>tools</artifactId>
-                <scope>system</scope>
-                <version>1.6</version>
-                <systemPath>${toolsjar}</systemPath>
+                <groupId>com.github.olivergondza</groupId>
+                <artifactId>maven-jdk-tools-wrapper</artifactId>
+                <version>0.1</version>
               </dependency>
             </dependencies>
           </plugin>
@@ -155,28 +151,6 @@
           </plugin>
         </plugins>
       </reporting>
-    </profile>
-    <profile>
-      <id>sane-jdk</id>
-      <activation>
-        <file>
-          <exists>${java.home}/../lib/tools.jar</exists>
-        </file>
-      </activation>
-      <properties>
-        <toolsjar>${java.home}/../lib/tools.jar</toolsjar>
-      </properties>
-    </profile>
-    <profile>
-      <id>osx-jdk</id>
-      <activation>
-        <file>
-          <exists>${java.home}/../Classes/classes.jar</exists>
-        </file>
-      </activation>
-      <properties>
-        <toolsjar>${java.home}/../Classes/classes.jar</toolsjar>
-      </properties>
     </profile>
   </profiles>
 </project>

--- a/jruby/pom.xml
+++ b/jruby/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>stapler-parent</artifactId>
     <version>1.238-SNAPSHOT</version>
   </parent>
-  
+
   <artifactId>stapler-jruby</artifactId>
   <name>Stapler JRuby module</name>
   <description>JRuby binding for Stapler</description>
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>org.jruby</groupId>
       <artifactId>jruby-complete</artifactId>
-      <version>1.7.3</version>
+      <version>1.7.17</version>
     </dependency>
     <dependency>
       <groupId>org.jruby.rack</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.9</version>
+        <version>1.14</version>
         <executions>
           <execution>
             <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -224,14 +224,14 @@
       </plugin>
     </plugins>
   </reporting>
-  
+
 
   <dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>org.kohsuke.metainf-services</groupId>
       <artifactId>metainf-services</artifactId>
-      <version>1.5</version>
+      <version>1.7</version>
     </dependency>
 
     <!-- test dependencies -->


### PR DESCRIPTION
- Update dependencies where needed
  - annotation-indexer ([to be released](https://github.com/jenkinsci/lib-annotation-indexer/pull/2))
  - jruby-complete
  - animal-sniffer-maven-plugin
  - metainf-services
- Replace explicit `tools.jar` dependency with [`maven-jdk-tools-wrapper`](https://github.com/olivergondza/maven-jdk-tools-wrapper)
- Fix tests and `java.nio.file.NoSuchFileException` usage