### PR TITLE
AcceptHeader doesn't honor relative weight in certain cases

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/AcceptHeader.java
+++ b/core/src/main/java/org/kohsuke/stapler/AcceptHeader.java
@@ -164,8 +164,8 @@ public final class AcceptHeader {
             int f = a.fit(target);
             if (f>bestFitness) {
                 best = a;
+                bestFitness = f;
             }
-            bestFitness = f;
         }
 
         return best;

--- a/core/src/test/java/org/kohsuke/stapler/AcceptHeaderTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/AcceptHeaderTest.java
@@ -107,4 +107,18 @@ public class AcceptHeaderTest {
         Assert.assertEquals(type, "image/png");
 
     }
+
+    @Test
+    public void qualityFactor6(){
+        AcceptHeader acceptHeader = new AcceptHeader("text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8");
+
+        String type = acceptHeader.select("text/plain", "text/html");
+        Assert.assertNotNull(type);
+        Assert.assertEquals(type, "text/html"); // 1 > 0.8
+
+        type = acceptHeader.select("text/plain", "application/xml");
+        Assert.assertNotNull(type);
+        Assert.assertEquals(type, "application/xml"); //0.9 > 0.8
+    }
+
 }


### PR DESCRIPTION
AcceptHeader.select() gives wrong result if first mime  type is of lower q value than the second parameter mime type.

Given this accept header:

    AcceptHeader ah = new AcceptHeader("    text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8");
    ah.select("text/plain", "text/html");  //gives text/plain, where as it should give text/html as text/html's q is 1 where as text/plain q is 0.8 (*/*)
