### PR TITLE
allow JSON responses to be compressed when serving with serveStaticResource

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/Stapler.java
+++ b/core/src/main/java/org/kohsuke/stapler/Stapler.java
@@ -1023,7 +1023,7 @@ public class Stapler extends HttpServlet {
      * Extensions that look like text files.
      */
     private static final Set<String> TEXT_FILES = new HashSet<String>(Arrays.asList(
-        "css","js","html","txt","java","htm","c","cpp","h","rb","pl","py","xml"
+        "css","js","html","txt","java","htm","c","cpp","h","rb","pl","py","xml","json"
     ));
 
     /**


### PR DESCRIPTION
To get served with compression, the MIME type of a static resource must either be `TEXT/*` or the file extension must be contained in `TEXT_FILES`. See https://github.com/stapler/stapler/blob/stapler-parent-1.244/core/src/main/java/org/kohsuke/stapler/Stapler.java#L532.

The MIME Type for `.json` files is `application/json`. JSON resources are never compressed since the MIME type is not `text/*` and `json` is not in `TEXT_FILES`.