### PR TITLE
Look for declared fields on superclass

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/lang/FieldRef.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/FieldRef.java
@@ -2,6 +2,7 @@ package org.kohsuke.stapler.lang;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 
 /**
  * Fields of {@link Klass}.
@@ -27,6 +28,13 @@ public abstract class FieldRef extends AnnotatedRef {
      */
     public abstract String getQualifiedName();
 
+    /**
+     * Returns true if this method is a 'public' method that should be used for routing requests.
+     */
+    public boolean isRoutable() {
+        return true;
+    }
+
     public static FieldRef wrap(final Field f) {
         f.setAccessible(true);
 
@@ -49,6 +57,11 @@ public abstract class FieldRef extends AnnotatedRef {
             @Override
             public String getQualifiedName() {
                 return f.getDeclaringClass().getName()+"."+getName();
+            }
+
+            @Override
+            public boolean isRoutable() {
+                return Modifier.isPublic(f.getModifiers());
             }
         };
     }

--- a/core/src/main/java/org/kohsuke/stapler/lang/Klass.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/Klass.java
@@ -67,7 +67,7 @@ public final class Klass<C> {
     public List<FieldRef> getFields() {
         Map<String,FieldRef> fields = new LinkedHashMap<String,FieldRef>();
         for (Klass<?> k = this; k!=null; k=k.getSuperClass()) {
-            for (FieldRef f : getDeclaredFields()) {
+            for (FieldRef f : k.getDeclaredFields()) {
                 String name = f.getName();
                 if (!fields.containsKey(name)) {
                     fields.put(name,f);

--- a/core/src/main/java/org/kohsuke/stapler/lang/Klass.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/Klass.java
@@ -69,7 +69,7 @@ public final class Klass<C> {
         for (Klass<?> k = this; k!=null; k=k.getSuperClass()) {
             for (FieldRef f : k.getDeclaredFields()) {
                 String name = f.getName();
-                if (!fields.containsKey(name)) {
+                if (!fields.containsKey(name) && f.isRoutable()) {
                     fields.put(name,f);
                 }
             }

--- a/core/src/main/java/org/kohsuke/stapler/lang/util/FieldRefFilter.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/util/FieldRefFilter.java
@@ -28,6 +28,11 @@ public abstract class FieldRefFilter extends FieldRef {
         return getBase().getQualifiedName();
     }
 
+    @Override
+    public boolean isRoutable() {
+        return getBase().isRoutable();
+    }
+
     public static FieldRef wrap(Field f) {
         return FieldRef.wrap(f);
     }

--- a/core/src/test/java/org/kohsuke/stapler/DispatcherTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DispatcherTest.java
@@ -272,4 +272,38 @@ public class DispatcherTest extends JettyTestCase {
         wc.getPage(new WebRequestSettings(url, HttpMethod.POST));
         assertEquals(1, requirePostOnBase.hit);
     }
+
+
+    public final TestWithPublicField testWithPublicField = new TestWithPublicField();
+
+    public  class TestWithPublicField extends TestWithPublicFieldBase{
+
+    }
+
+    public  class TestWithPublicFieldBase{
+        public TestClass testClass=new TestClass();
+    }
+
+
+    public  class TestClass{
+//        @GET @WebMethod(name="")
+        public String doValue(){
+            return "hello";
+        }
+    }
+
+    public void testPublicFieldDispatch() throws Exception {
+        WebClient wc = new WebClient();
+        URL url = new URL(this.url, "testWithPublicField/testClass/value/");
+
+        try {
+            wc.getPage(url);
+        } catch (FailingHttpStatusCodeException e) {
+            assertEquals(HttpServletResponse.SC_OK, e.getStatusCode());
+        }
+    }
+
+
+
+
 }

--- a/jruby/pom.xml
+++ b/jruby/pom.xml
@@ -83,5 +83,7 @@
       <artifactId>mockito-all</artifactId>
     </dependency>
   </dependencies>
+  <properties>
+    <skip.jruby.tests>${skipTests}</skip.jruby.tests>
+  </properties>
 </project>
-


### PR DESCRIPTION
Fixes regression where a declared field on a superclass not detected by stapler resulting in 404 when accessed from URL, as reported on https://github.com/jenkinsci/jenkins/pull/2415.