### PR TITLE
[JENKINS-32503] Update dependency of beanutils

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>1.7.0</version>
+      <version>1.9.3</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
@@ -441,7 +441,7 @@ public class DataBindingTest extends TestCase {
 
 
     public void testFluentSetter() {
-        FluentSetter fl = bind("{items : 'someItem'}", FluentSetter.class);
+        FluentSetter fl = bind("{items : ['someItem']}", FluentSetter.class);
         assertEquals(Arrays.asList("someItem"), fl.getItems());
     }
 }

--- a/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
@@ -422,7 +422,7 @@ public class DataBindingTest extends TestCase {
         public FluentSetter() {}
 
         /**
-         * WIP This tests passes in stapler, bad fluent doesn't work in jenkins...
+         * WIP This tests passes in stapler, but fluent doesn't work in jenkins...
          * @see FluentPropertyBeanIntrospector
          *
          * It is also possible to transform it to `withXXX()` to have clear vision.

--- a/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
@@ -3,6 +3,8 @@ package org.kohsuke.stapler;
 import junit.framework.TestCase;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.apache.commons.beanutils.FluentPropertyBeanIntrospector;
+import org.junit.Test;
 
 import javax.annotation.PostConstruct;
 import java.lang.reflect.Type;
@@ -411,5 +413,35 @@ public class DataBindingTest extends TestCase {
     public void testDerivedProperty() {
         DerivedProperty r = bind("{items:[1,3,5]}",DerivedProperty.class);
         assertEquals(Arrays.asList(1,3,5),r.getItems());
+    }
+
+    public static class FluentSetter {
+        private List<String> items;
+
+        @DataBoundConstructor
+        public FluentSetter() {}
+
+        /**
+         * WIP This tests passes in stapler, bad fluent doesn't work in jenkins...
+         * @see FluentPropertyBeanIntrospector
+         *
+         * It is also possible to transform it to `withXXX()` to have clear vision.
+         */
+        @DataBoundSetter
+//        public void setItems(List<String> items) {
+        public FluentSetter setItems(List<String> items) {
+            this.items = items;
+            return this;
+        }
+
+        public List<String> getItems() {
+            return items;
+        }
+    }
+
+
+    public void testFluentSetter() {
+        FluentSetter fl = bind("{items : 'someItem'}", FluentSetter.class);
+        assertEquals(Arrays.asList("someItem"), fl.getItems());
     }
 }


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-32503

Testing PR build with dependency update as is.
Jenkins is already on 1.8.3 https://github.com/jenkinsci/jenkins/blob/74c534207ca0b97b0345bf413b63f2450ccc8d04/core/pom.xml#L277-L279
That fails 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stapler/stapler/81)

<!-- Reviewable:end -->
