### PR TITLE
[JENKINS-39414] - Workaround Ruby Runtime Plugin and Jenkins 2.28 compatibility issues

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/lang/Klass.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/Klass.java
@@ -4,6 +4,7 @@ import org.kohsuke.stapler.Function;
 
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -56,7 +57,13 @@ public final class Klass<C> {
     }
 
     public List<FieldRef> getDeclaredFields() {
-        return navigator.getDeclaredFields(clazz);
+        try {
+            return navigator.getDeclaredFields(clazz);
+        } catch (AbstractMethodError err) {
+            // A plugin uses obsolete version of Stapler-dependent library (e.g. JRuby), which does not offer the method (JENKINS-39414)
+            // TODO: what to do with Logging? The error must be VERY visible, but it will totally pollute system logs
+            return Collections.emptyList();
+        }
     }
 
     /**

--- a/core/src/test/java/org/kohsuke/stapler/lang/KlassTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/lang/KlassTest.java
@@ -1,0 +1,30 @@
+package org.kohsuke.stapler.lang;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.List;
+
+/**
+ * Contains tests for {@link Klass}.
+ * @author Oleg Nenashev.
+ */
+public class KlassTest {
+
+    @Test
+    public void shouldProperlyAccessJavaDeclaredFields() throws Exception {
+        final Klass<Class> classInstance = Klass.java(FooClass.class);
+        final List<FieldRef> declaredFields = classInstance.getDeclaredFields();
+        for (FieldRef ref : declaredFields) {
+            if ("fooField".equals(ref.getName())) {
+                //TODO: check field parameters once Stapler provides such info
+                return;
+            }
+        }
+        Assert.fail("Have not found 'fooField' in the returned field list");
+    }
+
+    private static final class FooClass {
+        private int fooField;
+    }
+}

--- a/jruby/pom.xml
+++ b/jruby/pom.xml
@@ -82,6 +82,18 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci</groupId>
+      <artifactId>test-annotations</artifactId>
+      <version>1.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <properties>
     <skip.jruby.tests>${skipTests}</skip.jruby.tests>

--- a/jruby/src/test/java/org/kohsuke/stapler/jelly/jruby/RubyKlassNavigatorTest.java
+++ b/jruby/src/test/java/org/kohsuke/stapler/jelly/jruby/RubyKlassNavigatorTest.java
@@ -1,0 +1,76 @@
+package org.kohsuke.stapler.jelly.jruby;
+
+import org.jruby.CompatVersion;
+import org.jruby.Ruby;
+import org.jruby.RubyClass;
+import org.jruby.RubyModule;
+import org.jruby.embed.LocalContextScope;
+import org.jruby.embed.ScriptingContainer;
+import org.junit.Assert;
+import org.junit.Test;
+import org.kohsuke.stapler.lang.FieldRef;
+import org.kohsuke.stapler.lang.Klass;
+import org.jvnet.hudson.test.Issue;
+
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.*;
+import org.hamcrest.collection.IsEmptyCollection;
+import static org.junit.Assume.assumeThat;
+
+/**
+ * Tests handling of Ruby classes and modules with {@link RubyKlassNavigator}.
+ * @author Oleg Nenashev.
+ */
+public class RubyKlassNavigatorTest {
+
+    /**
+     * Verifies that field retrieval do not fail horribly for {@link RubyModule}.
+     * Effective use-case - Ruby Runtime Plugin for Jenkins.
+     * @throws Exception Test failure
+     */
+    @Test
+    @Issue("JENKINS-39414")
+    public void shouldProperlyHandleRubyModules() throws Exception {
+        final ScriptingContainer ruby = createRubyInstance();
+        final RubyKlassNavigator navigator = new RubyKlassNavigator(ruby.getProvider().getRuntime(), ClassLoader.getSystemClassLoader());
+        final MyRubyModule myModule = new MyRubyModule(ruby.getRuntime(), new MyRubyClass(ruby.getRuntime()), true);
+
+
+        final Klass<RubyModule> classInstance = new Klass<RubyModule>(myModule, navigator);
+        final List<FieldRef> declaredFields = classInstance.getDeclaredFields();
+
+        assumeThat("Access to fields in Ruby Modules has not been implemented yet",
+                declaredFields, not(IsEmptyCollection.<FieldRef>empty()));
+        for (FieldRef ref : declaredFields) {
+            if ("fooField".equals(ref.getName())) {
+                //TODO: check fields once implemented in Stapler
+                return;
+            }
+        }
+        Assert.fail("Have not found 'fooField' in the returned field list");
+    }
+
+    private static final class MyRubyModule extends RubyModule {
+
+        private int fooField = 123;
+
+        MyRubyModule(Ruby runtime, RubyClass metaClass, boolean objectSpace) {
+            super(runtime, metaClass, objectSpace);
+        }
+    }
+
+    private static final class MyRubyClass extends RubyClass {
+        MyRubyClass(Ruby runtime) {
+            super(runtime);
+        }
+    }
+
+    private ScriptingContainer createRubyInstance() {
+        // Similar to Ruby Runtime Plugin, but with non-Jenkins classloader
+        final ScriptingContainer ruby = new ScriptingContainer(LocalContextScope.SINGLETHREAD);
+        ruby.setCompatVersion(CompatVersion.RUBY1_9);
+        ruby.setClassLoader(ClassLoader.getSystemClassLoader());
+        return ruby;
+    }
+}


### PR DESCRIPTION
Stapler 1.266 was formally compatible if we take a set of modules, but we didn't take into account that components like `stapler-jruby` are actually standalone libs being bundled in plugins like Ruby Runtime.

Verifies there is no regression in the Jenkins core itself.

- [x] Add direct unit tests for Field processing for common and Ruby classes
- [x] Suppress error when a plugin uses obsolete lib (e.g. stapler-ruby in Ruby Runtime)

Error suppression is a weird approach, but I cannot offer anything better in the current state. A long-term fix would be to rework Stapler multi-module structure and to somehow ensure that entire stapler code gets delivered via something like core module

https://issues.jenkins-ci.org/browse/JENKINS-39414

@reviewbybees 