### PR TITLE
Define an annotation to inject `req.getSubmittedForm()`

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/StaplerRequest.java
+++ b/core/src/main/java/org/kohsuke/stapler/StaplerRequest.java
@@ -41,6 +41,7 @@ import java.util.List;
 import net.sf.json.JSONObject;
 import net.sf.json.JSONArray;
 import org.kohsuke.stapler.bind.BoundObjectTable;
+import org.kohsuke.stapler.json.SubmittedForm;
 import org.kohsuke.stapler.lang.Klass;
 
 /**
@@ -479,6 +480,7 @@ public interface StaplerRequest extends HttpServletRequest {
      * Gets the content of the structured form submission.
      *
      * @see <a href="https://wiki.jenkins-ci.org/display/JENKINS/Structured+Form+Submission">Structured Form Submission</a>
+     * @see SubmittedForm
      */
     JSONObject getSubmittedForm() throws ServletException;
 

--- a/core/src/main/java/org/kohsuke/stapler/json/SubmittedForm.java
+++ b/core/src/main/java/org/kohsuke/stapler/json/SubmittedForm.java
@@ -1,0 +1,44 @@
+package org.kohsuke.stapler.json;
+
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.AnnotationHandler;
+import org.kohsuke.stapler.InjectedParameter;
+import org.kohsuke.stapler.StaplerRequest;
+
+import javax.servlet.ServletException;
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.*;
+import static java.lang.annotation.RetentionPolicy.*;
+
+/**
+ * Binds {@linkplain StaplerRequest#getSubmittedForm() the submitted form} to a parameter of a web-bound method.
+ *
+ * <p>
+ * On a web-bound <tt>doXyz</tt> method, use this annotation on a parameter to get the submitted
+ * structured form content and inject it as {@link JSONObject}.
+ * For example,
+ *
+ * <pre>
+ * public HttpResponse doConfigSubmit(@SubmittedForm JSONObject o) {
+ *   ...
+ * }
+ * </pre>
+ *
+ * @author Kohsuke Kawaguchi
+ */
+@Target(PARAMETER)
+@Retention(RUNTIME)
+@Documented
+@InjectedParameter(SubmittedForm.Handler.class)
+public @interface SubmittedForm {
+    public static class Handler extends AnnotationHandler {
+        @Override
+        public Object parse(StaplerRequest request, Annotation a, Class type, String parameterName) throws ServletException {
+            return request.getSubmittedForm();
+        }
+    }
+}

--- a/core/src/test/java/org/kohsuke/stapler/json/SubmittedFormTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/json/SubmittedFormTest.java
@@ -1,0 +1,40 @@
+package org.kohsuke.stapler.json;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlForm;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.HttpResponse;
+import org.kohsuke.stapler.HttpResponses;
+import org.kohsuke.stapler.StaticViewFacet;
+import org.kohsuke.stapler.test.JettyTestCase;
+
+import java.net.URL;
+
+/**
+ * @author Kohsuke Kawaguchi
+ */
+public class SubmittedFormTest extends JettyTestCase {
+    /**
+     * To load form for test, allow *.html to be served as a view
+     */
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        webApp.facets.add(new StaticViewFacet("html"));
+    }
+
+    public void testMainFeature() throws Exception {
+        WebClient wc = new WebClient();
+        HtmlPage page = wc.getPage(new URL(url, "/form.html"));
+        HtmlForm f = page.getFormByName("main");
+        f.getInputByName("json").setValueAttribute("{\"first\":\"Kohsuke\",\"last\":\"Kawaguchi\"}");
+        f.submit();
+    }
+
+    public HttpResponse doSubmit(@SubmittedForm JSONObject o) {
+        assertEquals("Kohsuke",o.getString("first"));
+        assertEquals("Kawaguchi",o.getString("last"));
+        return HttpResponses.ok();
+    }
+}

--- a/core/src/test/resources/org/kohsuke/stapler/json/SubmittedFormTest/form.html
+++ b/core/src/test/resources/org/kohsuke/stapler/json/SubmittedFormTest/form.html
@@ -1,0 +1,8 @@
+<html>
+<body>
+    <form name="main">
+        <input type="text" name="json" />
+        <input type="submit" />
+    </form>
+</body>
+</html>


### PR DESCRIPTION
This makes it easier to write a `doConfigSubmit` method that's more amenable for overriding