### PR TITLE
[Performance] Use invoke dynamic instead of Method.invoke for @Exported

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         }
     }
 
-    postBuild {
+    post {
         success {
             archive "**/target/**/*.jar"
             junit '**/target/surefire-reports/*.xml'

--- a/core/src/main/java/org/kohsuke/stapler/Function.java
+++ b/core/src/main/java/org/kohsuke/stapler/Function.java
@@ -34,6 +34,9 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -49,6 +52,7 @@ import static org.kohsuke.stapler.ReflectionUtils.*;
  * @author Kohsuke Kawaguchi
  */
 public abstract class Function {
+
     /**
      * Gets the method name.
      */
@@ -332,7 +336,14 @@ public abstract class Function {
         }
 
         public Object invoke(StaplerRequest req, StaplerResponse rsp, Object o, Object... args) throws IllegalAccessException, InvocationTargetException {
-            return m.invoke(o, args);
+            Object[] arguments = new Object[args.length + 1];
+            arguments[0] = o;
+            System.arraycopy(args, 0, arguments, 1, args.length);
+            try {
+                return MethodHandleCache.get(m).invokeWithArguments(arguments);
+            } catch (Throwable throwable) {
+                throw new InvocationTargetException(throwable);
+            }
         }
     }
 

--- a/core/src/main/java/org/kohsuke/stapler/MethodHandleCache.java
+++ b/core/src/main/java/org/kohsuke/stapler/MethodHandleCache.java
@@ -1,0 +1,30 @@
+package org.kohsuke.stapler;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodHandles.Lookup;
+import java.lang.reflect.Method;
+import java.util.concurrent.TimeUnit;
+
+public final class MethodHandleCache {
+
+    public static MethodHandle get(Method method) {
+        return METHOD_HANDLES.getUnchecked(method);
+    }
+
+    private static final LoadingCache<Method, MethodHandle> METHOD_HANDLES = CacheBuilder.newBuilder().expireAfterAccess(1, TimeUnit.HOURS).build(new CacheLoader<Method, MethodHandle>() {
+
+        private final Lookup lookup = MethodHandles.lookup();
+
+        @Override
+        public MethodHandle load(Method method) throws Exception {
+            return lookup.unreflect(method);
+        }
+    });
+
+    private MethodHandleCache() {}
+}

--- a/core/src/main/java/org/kohsuke/stapler/export/MethodProperty.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/MethodProperty.java
@@ -24,20 +24,23 @@
 package org.kohsuke.stapler.export;
 
 import java.beans.Introspector;
+import java.lang.invoke.MethodHandle;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
-import java.io.IOException;
 
 /**
  * {@link Property} based on {@link Method}.
  * @author Kohsuke Kawaguchi
  */
 final class MethodProperty extends Property {
+    private final MethodHandle handle;
     private final Method method;
-    MethodProperty(Model owner, Method m, Exported exported) {
+
+    MethodProperty(Model owner, Method m, Exported exported, MethodHandle handle) {
         super(owner,buildName(m.getName()), m.getGenericReturnType(), exported);
         this.method = m;
+        this.handle = handle;
     }
 
     private static String buildName(String name) {
@@ -63,6 +66,10 @@ final class MethodProperty extends Property {
     }
 
     protected Object getValue(Object object) throws IllegalAccessException, InvocationTargetException {
-        return method.invoke(object);
+        try {
+            return handle.invoke(object);
+        } catch (Throwable throwable) {
+            throw new InvocationTargetException(throwable);
+        }
     }
 }

--- a/core/src/main/java/org/kohsuke/stapler/export/Model.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Model.java
@@ -25,6 +25,7 @@ package org.kohsuke.stapler.export;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.invoke.MethodHandle;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -41,6 +42,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
 import com.google.common.base.Predicate;
+import org.kohsuke.stapler.MethodHandleCache;
 import org.kohsuke.stapler.export.TreePruner.ByDepth;
 
 /**
@@ -100,11 +102,12 @@ public class Model<T> {
             if(m.getDeclaringClass()!=type) continue;
             if(m.isSynthetic() && m.isBridge()) continue;
             Exported exported = m.getAnnotation(Exported.class);
+            MethodHandle handle = MethodHandleCache.get(m);
             if(exported !=null) {
                 if (m.getParameterTypes().length > 0) {
                     LOGGER.log(Level.WARNING, "Method " + m.getName() + " of " + type.getName() + " is annotated @Exported but requires arguments");
                 } else {
-                    properties.add(new MethodProperty(this,m, exported));
+                    properties.add(new MethodProperty(this, m, exported, handle));
                 }
             }
         }

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.level>6</java.level>
+    <java.level>7</java.level>
   </properties>
 
   <build>
@@ -99,7 +99,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>animal-sniffer-maven-plugin</artifactId>
-        <version>1.14</version>
+        <version>1.15</version>
         <executions>
           <execution>
             <goals>
@@ -113,6 +113,10 @@
             <artifactId>java1${java.level}</artifactId>
             <version>1.0</version>
           </signature>
+          <ignores>
+            <!-- Detects as a false positive https://github.com/mojohaus/animal-sniffer/issues/18 -->
+            <ignore>java.lang.invoke.MethodHandle</ignore>
+          </ignores>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Use invoke dynamic (`MethodHandles`)  instead of Method.invoke for @Exported. 

`MethodHandles` seem to be what all the cool serialisers like protobuf use for performance reasons. This means that Stapler has to require JDK 7 minimum.

Initial testing seemed to show I could shave 20% off of the time to serve some Blue Ocean rest calls.