### PR TITLE
Optimization to reduce facet "index" search on every request

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
         }
     }
 
-    postBuild {
+    post {
         success {
             archive "**/target/**/*.jar"
             junit '**/target/surefire-reports/*.xml'

--- a/core/src/main/java/org/kohsuke/stapler/Stapler.java
+++ b/core/src/main/java/org/kohsuke/stapler/Stapler.java
@@ -708,8 +708,6 @@ public class Stapler extends HttpServlet {
             }
         }
 
-        MetaClass metaClass = webApp.getMetaClass(node);
-
         if(!req.tokens.hasMore()) {
             String servletPath = getServletPath(req);
             if(!servletPath.endsWith("/")) {
@@ -730,17 +728,9 @@ public class Stapler extends HttpServlet {
                     return true;
                 }
             }
-
-            for (Facet f : webApp.facets) {
-                if(f.handleIndexRequest(req,rsp,node,metaClass))
-                    return true;
-            }
-
-            URL indexHtml = getSideFileURL(node,"index.html");
-            if(indexHtml!=null && serveStaticResource(req,rsp,indexHtml,0))
-                return true; // done
         }
 
+        MetaClass metaClass = webApp.getMetaClass(node);
         try {
             for( Dispatcher d : metaClass.dispatchers ) {
                 if(d.dispatch(req,rsp,node)) {
@@ -794,6 +784,17 @@ public class Stapler extends HttpServlet {
                 }
             }
             throw new ServletException(cause);
+        }
+
+        if(!req.tokens.hasMore()) {
+            for (Facet f : webApp.facets) {
+                if(f.handleIndexRequest(req,rsp,node,metaClass))
+                    return true;
+            }
+
+            URL indexHtml = getSideFileURL(node,"index.html");
+            if(indexHtml!=null && serveStaticResource(req,rsp,indexHtml,0))
+                return true; // done
         }
 
         if(node instanceof StaplerFallback) {


### PR DESCRIPTION
Allows the dispatchers to run first and avoids searching the classpath for index files for each facet.