### PR TITLE
Detect wrong array type in RequestImpl.convertJSON()

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
@@ -485,7 +485,11 @@ public class RequestImpl extends HttpServletRequestWrapper implements StaplerReq
                 if(type==null)
                     continue;
 
-                fill(bean,key, type.convertJSON(src.get(key)));
+                try {
+                    fill(bean,key, type.convertJSON(src.get(key)));
+                } catch (WrongTypeException e) {
+                    throw new IllegalArgumentException(String.format("Error binding field %s: %s", key, e.getMessage()));
+                }
             }
         } catch (IllegalAccessException e) {
             IllegalAccessError x = new IllegalAccessError(e.getMessage());
@@ -715,6 +719,8 @@ public class RequestImpl extends HttpServletRequestWrapper implements StaplerReq
                 }
             }
             if (o instanceof JSONArray) {
+                if (l == null)
+                    throw new WrongTypeException(String.format("Got type array but no lister class found for type %s", type));
                 JSONArray a = (JSONArray) o;
                 TypePair itemType = new TypePair(l.itemGenericType,l.itemType);
                 for (Object item : a)

--- a/core/src/main/java/org/kohsuke/stapler/WrongTypeException.java
+++ b/core/src/main/java/org/kohsuke/stapler/WrongTypeException.java
@@ -1,0 +1,7 @@
+package org.kohsuke.stapler;
+
+public class WrongTypeException extends IllegalArgumentException {
+    public WrongTypeException(String s) {
+        super(s);
+    }
+}

--- a/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
@@ -36,6 +36,17 @@ public class DataBindingTest extends TestCase {
         assertEquals("string",data.myB);
     }
 
+    public void testMismatchingTypes() {
+        JSONObject json = new JSONObject();
+        json.put("b", new String[]{"v1", "v2"});
+        try {
+            Data data = bind(json, new Data());
+            fail("Should have thrown an IllegalArgumentException");
+        } catch (IllegalArgumentException e) {
+            assertEquals("Error binding field b: Got type array but no lister class found for type class java.lang.String", e.getMessage());
+        }
+    }
+
     public class DataEnumSet {
         public EnumSet<Proxy.Type> set;
     }


### PR DESCRIPTION
When the same parameter name is used several times in a form, it is
submitted as an array to Stapler, which in turn expects to find a list
type in the data model.  If this is not the case, report a meaningful
error message instead of a cryptic NPE.