### PR TITLE
Prefer doIndex over index views

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/DirectoryishDispatcher.java
+++ b/core/src/main/java/org/kohsuke/stapler/DirectoryishDispatcher.java
@@ -1,0 +1,42 @@
+package org.kohsuke.stapler;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * {@link Dispatcher} that tells browsers to append '/' to the request path and try again.
+ *
+ * If we are serving the index page, we demand that the URL be '/some/dir/' not '/some/dir'
+ * so that relative links in the page will resolve correctly. Apache does the same thing.
+ *
+ * @author Kohsuke Kawaguchi
+ */
+class DirectoryishDispatcher extends Dispatcher {
+    @Override
+    public boolean dispatch(RequestImpl req, ResponseImpl rsp, Object node) throws IOException, ServletException, IllegalAccessException, InvocationTargetException {
+        if(!req.tokens.hasMore()) {
+            String servletPath = req.stapler.getServletPath(req);
+            if(!servletPath.endsWith("/")) {
+                String target = req.getContextPath() + servletPath + '/';
+                if(req.getQueryString()!=null)
+                    target += '?' + req.getQueryString();
+                if(LOGGER.isLoggable(Level.FINER))
+                    LOGGER.finer("Redirecting to "+target);
+                rsp.sendRedirect2(target);
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "If path ends without '/' insert it";
+    }
+
+    private static final Logger LOGGER = Logger.getLogger(DirectoryishDispatcher.class.getName());
+}

--- a/core/src/main/java/org/kohsuke/stapler/HttpDeletable.java
+++ b/core/src/main/java/org/kohsuke/stapler/HttpDeletable.java
@@ -25,6 +25,7 @@ package org.kohsuke.stapler;
 
 import javax.servlet.ServletException;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
 
 /**
  * Marks the object that can handle HTTP DELETE.
@@ -36,4 +37,24 @@ public interface HttpDeletable {
      * Called when HTTP DELETE method is invoked.
      */
     void delete( StaplerRequest req, StaplerResponse rsp ) throws IOException, ServletException;
+}
+
+/**
+ * {@link Dispatcher} that processes {@link HttpDeletable}
+ */
+class HttpDeletableDispatcher extends Dispatcher {
+    @Override
+    public boolean dispatch(RequestImpl req, ResponseImpl rsp, Object node) throws IOException, ServletException, IllegalAccessException, InvocationTargetException {
+        if (!req.tokens.hasMore() && req.getMethod().equals("DELETE")) {
+            ((HttpDeletable)node).delete(req,rsp);
+            return true;
+        }
+
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "delete() for url=/ with DELETE";
+    }
 }

--- a/core/src/main/java/org/kohsuke/stapler/IndexViewDispatcher.java
+++ b/core/src/main/java/org/kohsuke/stapler/IndexViewDispatcher.java
@@ -1,0 +1,57 @@
+package org.kohsuke.stapler;
+
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * {@link Dispatcher} that deals with the "index" view pages that are used when the request path doesn't contain
+ * any token for the current object.
+ *
+ * <p>
+ * It is analogous to Apache serving a directory index if a directory itself is requested, as opposed to a file in it.
+ *
+ * @author Kohsuke Kawaguchi
+ */
+class IndexViewDispatcher extends Dispatcher {
+    private final MetaClass metaClass;
+
+    IndexViewDispatcher(MetaClass metaClass) {
+        this.metaClass = metaClass;
+    }
+
+    @Override
+    public boolean dispatch(RequestImpl req, ResponseImpl rsp, Object node) throws IOException, ServletException, IllegalAccessException, InvocationTargetException {
+        if (req.tokens.hasMore())
+            return false;
+
+        for (Facet f : metaClass.webApp.facets) {
+            if (f.handleIndexRequest(req, rsp, node, metaClass))
+                return true;
+        }
+
+        URL indexHtml = getSideFileURL(req.stapler, node, "index.html");
+        if (indexHtml != null) {
+            rsp.serveFile(req, indexHtml, 0);
+            return true; // done
+        }
+
+        return false;
+    }
+
+    private URL getSideFileURL(Stapler stapler, Object node, String fileName) throws MalformedURLException {
+        for (Class c = node.getClass(); c != Object.class; c = c.getSuperclass()) {
+            String name = "/WEB-INF/side-files/" + c.getName().replace('.', '/') + '/' + fileName;
+            URL url = stapler.getResource(name);
+            if (url != null) return url;
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "index views for url=/";
+    }
+}

--- a/core/src/main/java/org/kohsuke/stapler/MetaClass.java
+++ b/core/src/main/java/org/kohsuke/stapler/MetaClass.java
@@ -109,8 +109,6 @@ public class MetaClass extends TearOffSupport {
         if (HttpDeletable.class.isAssignableFrom(clazz))
             dispatchers.add(new HttpDeletableDispatcher());
 
-        dispatchers.add(new IndexViewDispatcher(this));
-
         // check action <obj>.do<token>(...) and other WebMethods
         for (Function f : node.methods.webMethods()) {
             WebMethod a = f.getAnnotation(WebMethod.class);
@@ -139,6 +137,11 @@ public class MetaClass extends TearOffSupport {
             }
         }
 
+        // check action <obj>.doIndex(...)
+        for (Function f : node.methods.name("doIndex")) {
+            dispatchers.add(new IndexDispatcher(f.contextualize(new WebMethodContext(""))));
+        }
+
         // JavaScript proxy method invocations for <obj>js<token>
         // reacts only to a specific content type
         for (Function f : node.methods.prefix("js") ) {
@@ -163,10 +166,7 @@ public class MetaClass extends TearOffSupport {
         for (Facet f : webApp.facets)
             f.buildViewDispatchers(this, dispatchers);
 
-        // check action <obj>.doIndex(...)
-        for (Function f : node.methods.name("doIndex")) {
-            dispatchers.add(new IndexDispatcher(f.contextualize(new WebMethodContext(""))));
-        }
+        dispatchers.add(new IndexViewDispatcher(this));
 
         // check public properties of the form NODE.TOKEN
         for (final FieldRef f : node.fields) {

--- a/core/src/main/java/org/kohsuke/stapler/MetaClass.java
+++ b/core/src/main/java/org/kohsuke/stapler/MetaClass.java
@@ -35,8 +35,6 @@ import javax.servlet.ServletException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -111,40 +109,7 @@ public class MetaClass extends TearOffSupport {
         if (HttpDeletable.class.isAssignableFrom(clazz))
             dispatchers.add(new HttpDeletableDispatcher());
 
-        dispatchers.add(new Dispatcher() {
-            @Override
-            public boolean dispatch(RequestImpl req, ResponseImpl rsp, Object node) throws IOException, ServletException, IllegalAccessException, InvocationTargetException {
-                if (req.tokens.hasMore())
-                    return false;
-
-                for (Facet f : webApp.facets) {
-                    if (f.handleIndexRequest(req, rsp, node, MetaClass.this))
-                        return true;
-                }
-
-                URL indexHtml = getSideFileURL(req.stapler, node, "index.html");
-                if (indexHtml != null) {
-                    rsp.serveFile(req, indexHtml, 0);
-                    return true; // done
-                }
-
-                return false;
-            }
-
-            private URL getSideFileURL(Stapler stapler, Object node, String fileName) throws MalformedURLException {
-                for (Class c = node.getClass(); c != Object.class; c = c.getSuperclass()) {
-                    String name = "/WEB-INF/side-files/" + c.getName().replace('.', '/') + '/' + fileName;
-                    URL url = stapler.getResource(name);
-                    if (url != null) return url;
-                }
-                return null;
-            }
-
-            @Override
-            public String toString() {
-                return "index views for url=/";
-            }
-        });
+        dispatchers.add(new IndexViewDispatcher(this));
 
         // check action <obj>.do<token>(...) and other WebMethods
         for (Function f : node.methods.webMethods()) {

--- a/core/src/main/java/org/kohsuke/stapler/MetaClass.java
+++ b/core/src/main/java/org/kohsuke/stapler/MetaClass.java
@@ -35,13 +35,11 @@ import javax.servlet.ServletException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.google.common.io.Resources.getResource;
 import static javax.servlet.http.HttpServletResponse.*;
 
 /**
@@ -106,6 +104,9 @@ public class MetaClass extends TearOffSupport {
     /*package*/ void buildDispatchers() {
         this.dispatchers.clear();
         KlassDescriptor<?> node = new KlassDescriptor(klass);
+
+        if (HttpDeletable.class.isAssignableFrom(clazz))
+            dispatchers.add(new HttpDeletableDispatcher());
 
         dispatchers.add(new Dispatcher() {
             @Override

--- a/core/src/main/java/org/kohsuke/stapler/MetaClass.java
+++ b/core/src/main/java/org/kohsuke/stapler/MetaClass.java
@@ -105,6 +105,8 @@ public class MetaClass extends TearOffSupport {
         this.dispatchers.clear();
         KlassDescriptor<?> node = new KlassDescriptor(klass);
 
+        dispatchers.add(new DirectoryishDispatcher());
+
         if (HttpDeletable.class.isAssignableFrom(clazz))
             dispatchers.add(new HttpDeletableDispatcher());
 

--- a/core/src/main/java/org/kohsuke/stapler/MetaClass.java
+++ b/core/src/main/java/org/kohsuke/stapler/MetaClass.java
@@ -35,6 +35,7 @@ import javax.servlet.ServletException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/core/src/main/java/org/kohsuke/stapler/Stapler.java
+++ b/core/src/main/java/org/kohsuke/stapler/Stapler.java
@@ -710,21 +710,6 @@ public class Stapler extends HttpServlet {
 
         MetaClass metaClass = webApp.getMetaClass(node);
 
-        if(!req.tokens.hasMore()) {
-            String servletPath = getServletPath(req);
-            if(!servletPath.endsWith("/")) {
-                // if we are serving the index page, we demand that the URL be '/some/dir/' not '/some/dir'
-                // so that relative links in the page will resolve correctly. Apache does the same thing.
-                String target = req.getContextPath() + servletPath + '/';
-                if(req.getQueryString()!=null)
-                    target += '?' + req.getQueryString();
-                if(LOGGER.isLoggable(Level.FINER))
-                    LOGGER.finer("Redirecting to "+target);
-                rsp.sendRedirect2(target);
-                return true;
-            }
-        }
-
         try {
             for( Dispatcher d : metaClass.dispatchers ) {
                 if(d.dispatch(req,rsp,node)) {
@@ -1004,7 +989,7 @@ public class Stapler extends HttpServlet {
     /**
      * Get raw servlet path (decoded in TokenList).
      */
-    private String getServletPath(HttpServletRequest req) {
+    /*package*/ String getServletPath(HttpServletRequest req) {
         return canonicalPath(req.getRequestURI().substring(req.getContextPath().length()));
     }
 

--- a/core/src/main/java/org/kohsuke/stapler/Stapler.java
+++ b/core/src/main/java/org/kohsuke/stapler/Stapler.java
@@ -730,15 +730,6 @@ public class Stapler extends HttpServlet {
                     return true;
                 }
             }
-
-            for (Facet f : webApp.facets) {
-                if(f.handleIndexRequest(req,rsp,node,metaClass))
-                    return true;
-            }
-
-            URL indexHtml = getSideFileURL(node,"index.html");
-            if(indexHtml!=null && serveStaticResource(req,rsp,indexHtml,0))
-                return true; // done
         }
 
         try {
@@ -907,19 +898,10 @@ public class Stapler extends HttpServlet {
         dispatcher.forward(req,new ResponseImpl(this,rsp));
     }
 
-    private URL getSideFileURL(Object node,String fileName) throws MalformedURLException {
-        for( Class c = node.getClass(); c!=Object.class; c=c.getSuperclass() ) {
-            String name = "/WEB-INF/side-files/"+c.getName().replace('.','/')+'/'+fileName;
-            URL url = getResource(name);
-            if(url!=null) return url;
-        }
-        return null;
-    }
-
     /**
      * {@link ServletContext#getResource(String)} with caching.
      */
-    private URL getResource(String name) throws MalformedURLException {
+    /*package*/ URL getResource(String name) throws MalformedURLException {
         if (resourcePaths!=null)
             return resourcePaths.get(name);
         else

--- a/core/src/main/java/org/kohsuke/stapler/Stapler.java
+++ b/core/src/main/java/org/kohsuke/stapler/Stapler.java
@@ -723,13 +723,6 @@ public class Stapler extends HttpServlet {
                 rsp.sendRedirect2(target);
                 return true;
             }
-
-            if(req.getMethod().equals("DELETE")) {
-                if(node instanceof HttpDeletable) {
-                    ((HttpDeletable)node).delete(req,rsp);
-                    return true;
-                }
-            }
         }
 
         try {

--- a/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
@@ -155,7 +155,7 @@ public class DataBindingTest extends TestCase {
 
     private RequestImpl createFakeRequest() {
         Stapler s = new Stapler();
-        s.setWebApp(new WebApp(null));
+        s.setWebApp(new WebApp(new MockServletContext()));
         return new RequestImpl(s, new MockRequest(), Collections.<AncestorImpl>emptyList(), null);
     }
 


### PR DESCRIPTION
Adjustment of pull request #97 

The goal of #97 was to improve performance of request routing to objects that do not have index views but do have the `doIndex` method. This is achieved by swapping the priority between those two routes, which was done in 8156216. This is strictly speaking an incompatible change, but in practice acceptable and preferrable because:

1. no valid code could have existed out there that has both index view and the `doIndex` method because the latter would have never been invoked
2. the change makes the relative order of view and web method the same between index (index.jelly vs doIndex) and regular routes (xyz.jelly vs doXyz.)

To make this possible, this PR also converts index view routing and a few other routes that were previously hard-coded in `Stapler.tryInvoke` into `Dispatcher` implementations.