### PR TITLE
Fast index view search

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/Facet.java
+++ b/core/src/main/java/org/kohsuke/stapler/Facet.java
@@ -54,6 +54,17 @@ public abstract class Facet {
     public abstract void buildViewDispatchers(MetaClass owner, List<Dispatcher> dispatchers);
 
     /**
+     * Adds {@link Dispatcher}s that serves the likes of {@code index.EXT}
+     *
+     * The default implementation invokes {@link #handleIndexRequest(RequestImpl, ResponseImpl, Object, MetaClass)}
+     * but facet implementations can improve runtime dispatch performance by testing the presence
+     * of index view page upfront.
+     */
+    public void buildIndexDispatchers(MetaClass owner, List<Dispatcher> dispatchers) {
+        dispatchers.add(new IndexViewDispatcher(owner,this));
+    }
+
+    /**
      * Adds {@link Dispatcher}s that do catch-all behaviours like "doDispatch" does.
      */
     public void buildFallbackDispatchers(MetaClass owner, List<Dispatcher> dispatchers) {}

--- a/core/src/main/java/org/kohsuke/stapler/IndexHtmlDispatcher.java
+++ b/core/src/main/java/org/kohsuke/stapler/IndexHtmlDispatcher.java
@@ -1,0 +1,52 @@
+package org.kohsuke.stapler;
+
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * Serve {@code index.html} from {@code WEB-INF/side-files} if that exists.
+ *
+ * @author Kohsuke Kawaguchi
+ */
+class IndexHtmlDispatcher extends Dispatcher {
+    private final URL html;
+
+    private IndexHtmlDispatcher(URL html) {
+        this.html = html;
+    }
+
+    @Override
+    public boolean dispatch(RequestImpl req, ResponseImpl rsp, Object node) throws IOException, ServletException, IllegalAccessException, InvocationTargetException {
+        if (!req.tokens.hasMore()) {
+            rsp.serveFile(req, html, 0);
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public String toString() {
+        return "index.html for url=/";
+    }
+
+    /**
+     * Returns a {@link IndexHtmlDispatcher} if and only if the said class has {@code index.html} as a side-file
+     */
+    static Dispatcher make(ServletContext context, Class c) {
+        for (; c != Object.class; c = c.getSuperclass()) {
+            String name = "/WEB-INF/side-files/" + c.getName().replace('.', '/') + "/index.html";
+            try {
+                URL url = context.getResource(name);
+                if (url != null)
+                    return new IndexHtmlDispatcher(url);
+            } catch (MalformedURLException e) {
+                throw new IllegalArgumentException(e);
+            }
+        }
+        return null;
+    }
+}

--- a/core/src/main/java/org/kohsuke/stapler/IndexHtmlDispatcher.java
+++ b/core/src/main/java/org/kohsuke/stapler/IndexHtmlDispatcher.java
@@ -3,7 +3,6 @@ package org.kohsuke.stapler;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.net.MalformedURLException;
 import java.net.URL;
 
@@ -15,12 +14,12 @@ import java.net.URL;
 class IndexHtmlDispatcher extends Dispatcher {
     private final URL html;
 
-    private IndexHtmlDispatcher(URL html) {
+    IndexHtmlDispatcher(URL html) {
         this.html = html;
     }
 
     @Override
-    public boolean dispatch(RequestImpl req, ResponseImpl rsp, Object node) throws IOException, ServletException, IllegalAccessException, InvocationTargetException {
+    public boolean dispatch(RequestImpl req, ResponseImpl rsp, Object node) throws IOException, ServletException {
         if (!req.tokens.hasMore()) {
             rsp.serveFile(req, html, 0);
             return true;

--- a/core/src/main/java/org/kohsuke/stapler/IndexViewDispatcher.java
+++ b/core/src/main/java/org/kohsuke/stapler/IndexViewDispatcher.java
@@ -15,9 +15,11 @@ import java.lang.reflect.InvocationTargetException;
  */
 class IndexViewDispatcher extends Dispatcher {
     private final MetaClass metaClass;
+    private final Facet facet;
 
-    IndexViewDispatcher(MetaClass metaClass) {
+    IndexViewDispatcher(MetaClass metaClass, Facet facet) {
         this.metaClass = metaClass;
+        this.facet = facet;
     }
 
     @Override
@@ -25,16 +27,14 @@ class IndexViewDispatcher extends Dispatcher {
         if (req.tokens.hasMore())
             return false;
 
-        for (Facet f : metaClass.webApp.facets) {
-            if (f.handleIndexRequest(req, rsp, node, metaClass))
-                return true;
-        }
+        if (facet.handleIndexRequest(req, rsp, node, metaClass))
+            return true;
 
         return false;
     }
 
     @Override
     public String toString() {
-        return "index views for url=/";
+        return "index view of "+facet+" for url=/";
     }
 }

--- a/core/src/main/java/org/kohsuke/stapler/IndexViewDispatcher.java
+++ b/core/src/main/java/org/kohsuke/stapler/IndexViewDispatcher.java
@@ -27,10 +27,7 @@ class IndexViewDispatcher extends Dispatcher {
         if (req.tokens.hasMore())
             return false;
 
-        if (facet.handleIndexRequest(req, rsp, node, metaClass))
-            return true;
-
-        return false;
+        return facet.handleIndexRequest(req, rsp, node, metaClass);
     }
 
     @Override

--- a/core/src/main/java/org/kohsuke/stapler/IndexViewDispatcher.java
+++ b/core/src/main/java/org/kohsuke/stapler/IndexViewDispatcher.java
@@ -3,8 +3,6 @@ package org.kohsuke.stapler;
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.net.MalformedURLException;
-import java.net.URL;
 
 /**
  * {@link Dispatcher} that deals with the "index" view pages that are used when the request path doesn't contain
@@ -32,22 +30,7 @@ class IndexViewDispatcher extends Dispatcher {
                 return true;
         }
 
-        URL indexHtml = getSideFileURL(req.stapler, node, "index.html");
-        if (indexHtml != null) {
-            rsp.serveFile(req, indexHtml, 0);
-            return true; // done
-        }
-
         return false;
-    }
-
-    private URL getSideFileURL(Stapler stapler, Object node, String fileName) throws MalformedURLException {
-        for (Class c = node.getClass(); c != Object.class; c = c.getSuperclass()) {
-            String name = "/WEB-INF/side-files/" + c.getName().replace('.', '/') + '/' + fileName;
-            URL url = stapler.getResource(name);
-            if (url != null) return url;
-        }
-        return null;
     }
 
     @Override

--- a/core/src/main/java/org/kohsuke/stapler/MetaClass.java
+++ b/core/src/main/java/org/kohsuke/stapler/MetaClass.java
@@ -433,6 +433,11 @@ public class MetaClass extends TearOffSupport {
         }
     }
 
+    @Override
+    public String toString() {
+        return "MetaClass["+klass+"]";
+    }
+
     private static String camelize(String name) {
         return Character.toLowerCase(name.charAt(0))+name.substring(1);
     }

--- a/core/src/main/java/org/kohsuke/stapler/MetaClass.java
+++ b/core/src/main/java/org/kohsuke/stapler/MetaClass.java
@@ -167,7 +167,7 @@ public class MetaClass extends TearOffSupport {
             f.buildViewDispatchers(this, dispatchers);
 
         for (Facet f : webApp.facets)
-            dispatchers.add(new IndexViewDispatcher(this, f));
+            f.buildIndexDispatchers(this, dispatchers);
 
         Dispatcher d = IndexHtmlDispatcher.make(webApp.context, clazz);
         if (d!=null)

--- a/core/src/main/java/org/kohsuke/stapler/MetaClass.java
+++ b/core/src/main/java/org/kohsuke/stapler/MetaClass.java
@@ -65,7 +65,7 @@ public class MetaClass extends TearOffSupport {
      */
     public final MetaClassLoader classLoader;
 
-    public final List<Dispatcher> dispatchers = new ArrayList<Dispatcher>();
+    public final List<Dispatcher> dispatchers = new ArrayList<>();
 
     /**
      * Base metaclass.
@@ -167,6 +167,9 @@ public class MetaClass extends TearOffSupport {
             f.buildViewDispatchers(this, dispatchers);
 
         dispatchers.add(new IndexViewDispatcher(this));
+        Dispatcher d = IndexHtmlDispatcher.make(webApp.context, clazz);
+        if (d!=null)
+            dispatchers.add(d);
 
         // check public properties of the form NODE.TOKEN
         for (final FieldRef f : node.fields) {

--- a/core/src/main/java/org/kohsuke/stapler/MetaClass.java
+++ b/core/src/main/java/org/kohsuke/stapler/MetaClass.java
@@ -166,7 +166,9 @@ public class MetaClass extends TearOffSupport {
         for (Facet f : webApp.facets)
             f.buildViewDispatchers(this, dispatchers);
 
-        dispatchers.add(new IndexViewDispatcher(this));
+        for (Facet f : webApp.facets)
+            dispatchers.add(new IndexViewDispatcher(this, f));
+
         Dispatcher d = IndexHtmlDispatcher.make(webApp.context, clazz);
         if (d!=null)
             dispatchers.add(d);

--- a/core/src/main/java/org/kohsuke/stapler/StaticViewFacet.java
+++ b/core/src/main/java/org/kohsuke/stapler/StaticViewFacet.java
@@ -107,10 +107,17 @@ public class StaticViewFacet extends Facet {
         };
     }
 
+    @Override
+    public void buildIndexDispatchers(MetaClass owner, List<Dispatcher> dispatchers) {
+        URL res = findResource(owner.klass, "index.html");
+        if (res!=null) {
+            dispatchers.add(new IndexHtmlDispatcher(res));
+        }
+    }
+
     public boolean handleIndexRequest(RequestImpl req, ResponseImpl rsp, Object node, MetaClass nodeMetaClass) throws IOException, ServletException {
         URL res = findResource(nodeMetaClass.klass,"index.html");
         if (res==null)  return false;
-        rsp.serveFile(req,res);
-        return true;
+        return new IndexHtmlDispatcher(res).dispatch(req,rsp,node);
     }
 }

--- a/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/GroovyFacet.java
+++ b/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/GroovyFacet.java
@@ -23,6 +23,7 @@
 
 package org.kohsuke.stapler.jelly.groovy;
 
+import org.apache.commons.jelly.JellyException;
 import org.apache.commons.jelly.Script;
 import org.kohsuke.MetaInfServices;
 import org.kohsuke.stapler.Dispatcher;
@@ -31,6 +32,7 @@ import org.kohsuke.stapler.MetaClass;
 import org.kohsuke.stapler.RequestImpl;
 import org.kohsuke.stapler.ResponseImpl;
 import org.kohsuke.stapler.WebApp;
+import org.kohsuke.stapler.jelly.JellyClassTearOff;
 import org.kohsuke.stapler.jelly.JellyCompatibleFacet;
 import org.kohsuke.stapler.jelly.JellyFacet;
 import org.kohsuke.stapler.lang.Klass;
@@ -42,6 +44,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Level;
 
 /**
  * {@link Facet} that brings in Groovy support on top of Jelly.
@@ -112,6 +115,17 @@ public class GroovyFacet extends Facet implements JellyCompatibleFacet {
         if (d==null)
             d = mc.loadTearOff(GroovyServerPageTearOff.class).createDispatcher(it, viewName);
         return d;
+    }
+
+    @Override
+    public void buildIndexDispatchers(MetaClass owner, List<Dispatcher> dispatchers) {
+        try {
+            if (owner.loadTearOff(JellyClassTearOff.class).findScript("index")!=null) {
+                super.buildIndexDispatchers(owner, dispatchers);
+            }
+        } catch (JellyException e) {
+            LOGGER.log(Level.WARNING, "Failed to parse index.groovy for "+owner, e);
+        }
     }
 
     public boolean handleIndexRequest(RequestImpl req, ResponseImpl rsp, Object node, MetaClass nodeMetaClass) throws IOException, ServletException {

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyFacet.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyFacet.java
@@ -23,6 +23,7 @@
 
 package org.kohsuke.stapler.jelly;
 
+import org.apache.commons.jelly.JellyException;
 import org.apache.commons.jelly.Script;
 import org.apache.commons.jelly.expression.ExpressionFactory;
 import org.kohsuke.MetaInfServices;
@@ -43,6 +44,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Level;
 
 /**
  * {@link Facet} that adds Jelly as the view.
@@ -108,6 +110,17 @@ public class JellyFacet extends Facet implements JellyCompatibleFacet {
                 return "VIEW.jelly for url=/VIEW";
             }
         });
+    }
+
+    @Override
+    public void buildIndexDispatchers(MetaClass owner, List<Dispatcher> dispatchers) {
+        try {
+            if (owner.loadTearOff(JellyClassTearOff.class).findScript("index.jelly")!=null) {
+                super.buildIndexDispatchers(owner, dispatchers);
+            }
+        } catch (JellyException e) {
+            LOGGER.log(Level.WARNING, "Failed to parse index.jelly for "+owner, e);
+        }
     }
 
     public Collection<Class<JellyClassTearOff>> getClassTearOffTypes() {

--- a/jrebel/src/main/java/org/kohsuke/stapler/JRebelFacet.java
+++ b/jrebel/src/main/java/org/kohsuke/stapler/JRebelFacet.java
@@ -74,6 +74,11 @@ public class JRebelFacet extends Facet {
     }
 
     @Override
+    public void buildIndexDispatchers(MetaClass owner, List<Dispatcher> dispatchers) {
+        // no-op
+    }
+
+    @Override
     public boolean handleIndexRequest(RequestImpl req, ResponseImpl rsp, Object node, MetaClass nodeMetaClass) {
         return false;
     }


### PR DESCRIPTION
This PR builds on top of PR #101 to improve the request routing performance by resolving the available index view routes upfront.

That is, instead of looking for a presence of `index.jelly` (and the likes) at the request processing time, this change makes that check happen during `MetaClass` construction time.