### PR TITLE
Fix use of MethodHandle on web methods which were accidentally static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 CHANGELOG
 ===
 
+##### 1.250
+Fix use of `static` methods in PR 96 in 1.249.
+
 ##### 1.249
 Release date: January 18, 2017
 * [PR 89](https://github.com/stapler/stapler/pull/89) -

--- a/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
@@ -79,6 +79,7 @@ public class DataBindingTest extends TestCase {
         RequestImpl req = new RequestImpl(new Stapler(), mr, Collections.<AncestorImpl>emptyList(), null);
         new Function.InstanceFunction(getClass().getMethod("doFromStaplerMethod",StaplerRequest.class,int.class,Binder.class))
                 .bindAndInvoke(this,req,null);
+        assertEquals(42, new Function.InstanceFunction(getClass().getMethod("doStaticMethod")).bindAndInvoke(this, req, null));
     }
 
     public void doFromStaplerMethod(StaplerRequest req, @QueryParameter int a, Binder b) {
@@ -87,6 +88,8 @@ public class DataBindingTest extends TestCase {
         assertEquals("string",b.b);
 
     }
+
+    public static int doStaticMethod() {return 42;}
 
     public static class Binder {
         StaplerRequest req;


### PR DESCRIPTION
Corrects a regression in #96 caught by tests in https://github.com/jenkinsci/jenkins/pull/2722. [This code](https://github.com/jenkinsci/cvs-plugin/blob/9390d5ae0b07c29c87adc87ae10be302507a5347/src/main/java/hudson/scm/CvsRepository.java#L221) in the CVS plugin is a mistake, but was apparently tolerated before.

@reviewbybees esp. @i386