### PR TITLE
[JENKINS-41729] Allow UTF-8 property files

### DIFF
--- a/jelly/src/test/java/org/kohsuke/stapler/jelly/ResourceBundleTest.java
+++ b/jelly/src/test/java/org/kohsuke/stapler/jelly/ResourceBundleTest.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2017 IKEDA Yasuyuki
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.kohsuke.stapler.jelly;
+
+import java.net.URL;
+
+import org.kohsuke.stapler.test.JettyTestCase;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+
+/**
+ * Tests for {@link ResourceBundle}
+ */
+public class ResourceBundleTest extends JettyTestCase{
+    public void testUtf8PropertyFile() throws Exception {
+        WebClient wc = new WebClient();
+        wc.addRequestHeader("Accept-Language", "en-US");
+        HtmlPage page = wc.getPage(new URL(url, "/"));
+        assertEquals("日本語", page.getElementById("language").getTextContent());
+    }
+}

--- a/jelly/src/test/java/org/kohsuke/stapler/jelly/ResourceBundleTest.java
+++ b/jelly/src/test/java/org/kohsuke/stapler/jelly/ResourceBundleTest.java
@@ -76,6 +76,13 @@ public class ResourceBundleTest extends JettyTestCase{
         assertEquals("日本語", page.getElementById("language").getTextContent());
     }
 
+    public void testIso8859_1File() throws Exception {
+        WebClient wc = new WebClient();
+        wc.addRequestHeader("Accept-Language", "fr-FR");
+        HtmlPage page = wc.getPage(new URL(url, "/"));
+        assertEquals("Français", page.getElementById("language").getTextContent());
+    }
+
     public void testEncodedPropertyFile() throws Exception {
         WebClient wc = new WebClient();
         wc.addRequestHeader("Accept-Language", "ja-JP");

--- a/jelly/src/test/java/org/kohsuke/stapler/jelly/ResourceBundleTest.java
+++ b/jelly/src/test/java/org/kohsuke/stapler/jelly/ResourceBundleTest.java
@@ -75,4 +75,11 @@ public class ResourceBundleTest extends JettyTestCase{
         HtmlPage page = wc.getPage(new URL(url, "/"));
         assertEquals("日本語", page.getElementById("language").getTextContent());
     }
+
+    public void testEncodedPropertyFile() throws Exception {
+        WebClient wc = new WebClient();
+        wc.addRequestHeader("Accept-Language", "ja-JP");
+        HtmlPage page = wc.getPage(new URL(url, "/encoded"));
+        assertEquals("日本語", page.getElementById("language").getTextContent());
+    }
 }

--- a/jelly/src/test/resources/org/kohsuke/stapler/jelly/ResourceBundleTest/encoded.jelly
+++ b/jelly/src/test/resources/org/kohsuke/stapler/jelly/ResourceBundleTest/encoded.jelly
@@ -1,0 +1,12 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:st="jelly:stapler" xmlns:j="jelly:core">
+<st:contentType value="text/html; charset=UTF-8" />
+<html>
+  <head>
+    <title>ResourceBundleTest encoded property file</title>
+  </head>
+  <body>
+    <div id="language">${%Language}</div>
+  </body>
+</html>
+</j:jelly>

--- a/jelly/src/test/resources/org/kohsuke/stapler/jelly/ResourceBundleTest/encoded_ja.properties
+++ b/jelly/src/test/resources/org/kohsuke/stapler/jelly/ResourceBundleTest/encoded_ja.properties
@@ -1,0 +1,3 @@
+# "Japanese" in Japanese text
+# Language=日本語
+Language=\u65e5\u672c\u8a9e

--- a/jelly/src/test/resources/org/kohsuke/stapler/jelly/ResourceBundleTest/index.jelly
+++ b/jelly/src/test/resources/org/kohsuke/stapler/jelly/ResourceBundleTest/index.jelly
@@ -1,0 +1,12 @@
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:st="jelly:stapler" xmlns:j="jelly:core">
+<st:contentType value="text/html; charset=UTF-8" />
+<html>
+  <head>
+    <title>ResourceBundleTest</title>
+  </head>
+  <body>
+    <div id="language">${%Language}</div>
+  </body>
+</html>
+</j:jelly>

--- a/jelly/src/test/resources/org/kohsuke/stapler/jelly/ResourceBundleTest/index_fr.properties
+++ b/jelly/src/test/resources/org/kohsuke/stapler/jelly/ResourceBundleTest/index_fr.properties
@@ -1,0 +1,2 @@
+# Encoded with ISO-8859-1 (Latin-1)
+Language=Français

--- a/jelly/src/test/resources/org/kohsuke/stapler/jelly/ResourceBundleTest/index_ja.properties
+++ b/jelly/src/test/resources/org/kohsuke/stapler/jelly/ResourceBundleTest/index_ja.properties
@@ -1,0 +1,2 @@
+# "Japanese" in Japanese text
+Language=日本語


### PR DESCRIPTION
[JENKINS-41729](https://issues.jenkins-ci.org/browse/JENKINS-41729)

It's difficult to review localization pull requests for Jenkins plugins in github, as property files are encoded.
I have to review them in IDE.

This change makes stapler accept UTF-8 property files for localization, and property files no longer need to be encoded.

Actually, I'm not sure accepting UTF-8 files is the best approach, and I want comments about this change.
