### PR TITLE
JENKINS-40088# Configurable stapler serialization behavior

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/ResponseImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/ResponseImpl.java
@@ -23,26 +23,6 @@
 
 package org.kohsuke.stapler;
 
-import com.jcraft.jzlib.GZIPOutputStream;
-import net.sf.json.JsonConfig;
-import org.apache.commons.io.IOUtils;
-import org.kohsuke.stapler.compression.CompressionFilter;
-import org.kohsuke.stapler.compression.FilterServletOutputStream;
-import org.kohsuke.stapler.export.DataWriter;
-import org.kohsuke.stapler.export.ExportConfig;
-import org.kohsuke.stapler.export.Flavor;
-import org.kohsuke.stapler.export.Model;
-import org.kohsuke.stapler.export.ModelBuilder;
-import org.kohsuke.stapler.export.NamedPathPruner;
-import org.kohsuke.stapler.export.TreePruner;
-import org.kohsuke.stapler.export.TreePruner.ByDepth;
-
-import javax.annotation.Nonnull;
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import javax.servlet.http.HttpServletResponseWrapper;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -56,6 +36,26 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import javax.annotation.Nonnull;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpServletResponseWrapper;
+
+import com.jcraft.jzlib.GZIPOutputStream;
+import net.sf.json.JsonConfig;
+import org.apache.commons.io.IOUtils;
+import org.kohsuke.stapler.compression.CompressionFilter;
+import org.kohsuke.stapler.compression.FilterServletOutputStream;
+import org.kohsuke.stapler.export.DataWriter;
+import org.kohsuke.stapler.export.ExportConfig;
+import org.kohsuke.stapler.export.Flavor;
+import org.kohsuke.stapler.export.Model;
+import org.kohsuke.stapler.export.ModelBuilder;
+import org.kohsuke.stapler.export.NamedPathPruner;
+import org.kohsuke.stapler.export.TreePruner;
+import org.kohsuke.stapler.export.TreePruner.ByDepth;
 
 /**
  * {@link StaplerResponse} implementation.
@@ -231,7 +231,7 @@ public class ResponseImpl extends HttpServletResponseWrapper implements StaplerR
 
     @SuppressWarnings({"unchecked", "rawtypes"}) // API design flaw prevents this from type-checking
     public void serveExposedBean(StaplerRequest req, Object exposedBean, Flavor flavor) throws ServletException, IOException {
-        serveExposedBean(req, exposedBean, new ExportConfig.Builder(flavor).prettyPrint(req.hasParameter("pretty")).build());
+        serveExposedBean(req, exposedBean, new ExportConfig().withFlavor(flavor).withPrettyPrint(req.hasParameter("pretty")));
     }
 
     @Override

--- a/core/src/main/java/org/kohsuke/stapler/ResponseImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/ResponseImpl.java
@@ -231,12 +231,13 @@ public class ResponseImpl extends HttpServletResponseWrapper implements StaplerR
 
     @SuppressWarnings({"unchecked", "rawtypes"}) // API design flaw prevents this from type-checking
     public void serveExposedBean(StaplerRequest req, Object exposedBean, Flavor flavor) throws ServletException, IOException {
-        serveExposedBean(req, exposedBean, flavor, new ExportConfig());
+        serveExposedBean(req, exposedBean, new ExportConfig.Builder(flavor).prettyPrint(req.hasParameter("pretty")).build());
     }
 
     @Override
-    public void serveExposedBean(StaplerRequest req, Object exposedBean, Flavor flavor, ExportConfig config) throws ServletException, IOException {
+    public void serveExposedBean(StaplerRequest req, Object exposedBean, ExportConfig config) throws ServletException, IOException {
         String pad=null;
+        Flavor flavor = config.getFlavor();
         setContentType(flavor.contentType);
         Writer w = getCompressedWriter(req);
 
@@ -265,9 +266,6 @@ public class ResponseImpl extends HttpServletResponseWrapper implements StaplerR
             }
             pruner = new ByDepth(1 - depth);
         }
-
-        config.prettyPrint = req.hasParameter("pretty");
-
         DataWriter dw = flavor.createDataWriter(exposedBean, w, config);
         if (exposedBean instanceof Object[]) {
             // TODO: extend the contract of DataWriter to capture this
@@ -282,7 +280,6 @@ public class ResponseImpl extends HttpServletResponseWrapper implements StaplerR
 
         if(pad!=null) w.write(')');
         w.close();
-
     }
 
     private void writeOne(TreePruner pruner, DataWriter dw, Object item) throws IOException {

--- a/core/src/main/java/org/kohsuke/stapler/ResponseImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/ResponseImpl.java
@@ -23,39 +23,39 @@
 
 package org.kohsuke.stapler;
 
+import com.jcraft.jzlib.GZIPOutputStream;
 import net.sf.json.JsonConfig;
+import org.apache.commons.io.IOUtils;
 import org.kohsuke.stapler.compression.CompressionFilter;
 import org.kohsuke.stapler.compression.FilterServletOutputStream;
 import org.kohsuke.stapler.export.DataWriter;
 import org.kohsuke.stapler.export.ExportConfig;
-import org.kohsuke.stapler.export.NamedPathPruner;
 import org.kohsuke.stapler.export.Flavor;
 import org.kohsuke.stapler.export.Model;
 import org.kohsuke.stapler.export.ModelBuilder;
-import org.apache.commons.io.IOUtils;
+import org.kohsuke.stapler.export.NamedPathPruner;
+import org.kohsuke.stapler.export.TreePruner;
+import org.kohsuke.stapler.export.TreePruner.ByDepth;
 
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import javax.servlet.ServletOutputStream;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
-import javax.servlet.http.HttpServletRequest;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
 import java.io.InputStream;
-import java.io.PrintWriter;
 import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
 import java.io.Writer;
-import java.net.URL;
 import java.net.HttpURLConnection;
-import com.jcraft.jzlib.GZIPOutputStream;
+import java.net.URL;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import org.kohsuke.stapler.export.TreePruner;
-import org.kohsuke.stapler.export.TreePruner.ByDepth;
 
 /**
  * {@link StaplerResponse} implementation.
@@ -231,6 +231,11 @@ public class ResponseImpl extends HttpServletResponseWrapper implements StaplerR
 
     @SuppressWarnings({"unchecked", "rawtypes"}) // API design flaw prevents this from type-checking
     public void serveExposedBean(StaplerRequest req, Object exposedBean, Flavor flavor) throws ServletException, IOException {
+        serveExposedBean(req, exposedBean, flavor, new ExportConfig());
+    }
+
+    @Override
+    public void serveExposedBean(StaplerRequest req, Object exposedBean, Flavor flavor, ExportConfig config) throws ServletException, IOException {
         String pad=null;
         setContentType(flavor.contentType);
         Writer w = getCompressedWriter(req);
@@ -239,7 +244,7 @@ public class ResponseImpl extends HttpServletResponseWrapper implements StaplerR
             pad = req.getParameter("jsonp");
             if(pad!=null) w.write(pad+'(');
         }
-        
+
         TreePruner pruner;
         String tree = req.getParameter("tree");
         if (tree != null) {
@@ -261,7 +266,6 @@ public class ResponseImpl extends HttpServletResponseWrapper implements StaplerR
             pruner = new ByDepth(1 - depth);
         }
 
-        ExportConfig config = new ExportConfig();
         config.prettyPrint = req.hasParameter("pretty");
 
         DataWriter dw = flavor.createDataWriter(exposedBean, w, config);
@@ -278,6 +282,7 @@ public class ResponseImpl extends HttpServletResponseWrapper implements StaplerR
 
         if(pad!=null) w.write(')');
         w.close();
+
     }
 
     private void writeOne(TreePruner pruner, DataWriter dw, Object item) throws IOException {

--- a/core/src/main/java/org/kohsuke/stapler/StaplerResponse.java
+++ b/core/src/main/java/org/kohsuke/stapler/StaplerResponse.java
@@ -24,20 +24,22 @@
 package org.kohsuke.stapler;
 
 import net.sf.json.JsonConfig;
+import org.kohsuke.stapler.export.DataWriter;
+import org.kohsuke.stapler.export.ExportConfig;
 import org.kohsuke.stapler.export.Flavor;
+import org.kohsuke.stapler.export.Model;
+import org.kohsuke.stapler.export.NamedPathPruner;
 
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
-import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Writer;
 import java.net.URL;
 import java.net.URLConnection;
-import org.kohsuke.stapler.export.Model;
-import org.kohsuke.stapler.export.NamedPathPruner;
 
 /**
  * Defines additional operations made available by Stapler.
@@ -173,8 +175,28 @@ public interface StaplerResponse extends HttpServletResponse {
      * 
      * <p>As of 1.146, the {@code tree} parameter may be used to control the output
      * in detail; see {@link NamedPathPruner#NamedPathPruner(String)} for details.
+     *
+     * @deprecated Use {@link #serveExposedBean(StaplerRequest, Object, Flavor, ExportConfig)}
      */
+    @Deprecated
     void serveExposedBean(StaplerRequest req, Object exposedBean, Flavor flavor) throws ServletException,IOException;
+
+    /**
+     * Serves the exposed bean in the specified flavor.
+     *
+     * <p>
+     * This method performs the complete output from the header to the response body.
+     * If the flavor is JSON, this method also supports JSONP via the {@code jsonp} query parameter.
+     *
+     * <p>The {@code depth} parameter may be used to specify a recursion depth
+     * as in {@link Model#writeTo(Object,int,DataWriter)}
+     *
+     * <p>As of 1.146, the {@code tree} parameter may be used to control the output
+     * in detail; see {@link NamedPathPruner#NamedPathPruner(String)} for details.
+     *
+     * <p> {@link ExportConfig} is passed by the caller to control serialization behavior
+     */
+    void serveExposedBean(StaplerRequest req, Object exposedBean, Flavor flavor, ExportConfig exportConfig) throws ServletException,IOException;
 
     /**
      * Works like {@link #getOutputStream()} but tries to send the response

--- a/core/src/main/java/org/kohsuke/stapler/StaplerResponse.java
+++ b/core/src/main/java/org/kohsuke/stapler/StaplerResponse.java
@@ -176,7 +176,7 @@ public interface StaplerResponse extends HttpServletResponse {
      * <p>As of 1.146, the {@code tree} parameter may be used to control the output
      * in detail; see {@link NamedPathPruner#NamedPathPruner(String)} for details.
      *
-     * @deprecated Use {@link #serveExposedBean(StaplerRequest, Object, Flavor, ExportConfig)}
+     * @deprecated Use {@link #serveExposedBean(StaplerRequest, Object, ExportConfig)}
      */
     @Deprecated
     void serveExposedBean(StaplerRequest req, Object exposedBean, Flavor flavor) throws ServletException,IOException;
@@ -196,7 +196,7 @@ public interface StaplerResponse extends HttpServletResponse {
      *
      * <p> {@link ExportConfig} is passed by the caller to control serialization behavior
      */
-    void serveExposedBean(StaplerRequest req, Object exposedBean, Flavor flavor, ExportConfig exportConfig) throws ServletException,IOException;
+    void serveExposedBean(StaplerRequest req, Object exposedBean, ExportConfig exportConfig) throws ServletException,IOException;
 
     /**
      * Works like {@link #getOutputStream()} but tries to send the response

--- a/core/src/main/java/org/kohsuke/stapler/StaplerResponseWrapper.java
+++ b/core/src/main/java/org/kohsuke/stapler/StaplerResponseWrapper.java
@@ -1,5 +1,14 @@
 package org.kohsuke.stapler;
 
+import net.sf.json.JsonConfig;
+import org.kohsuke.stapler.export.ExportConfig;
+import org.kohsuke.stapler.export.Flavor;
+
+import javax.annotation.Nonnull;
+import javax.servlet.ServletException;
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -7,18 +16,6 @@ import java.io.PrintWriter;
 import java.io.Writer;
 import java.net.URL;
 import java.util.Locale;
-
-import javax.annotation.Nonnull;
-import javax.servlet.ServletException;
-import javax.servlet.ServletOutputStream;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-
-import org.kohsuke.stapler.StaplerRequest;
-import org.kohsuke.stapler.StaplerResponse;
-import org.kohsuke.stapler.export.Flavor;
-
-import net.sf.json.JsonConfig;
 
 /**
  * A basic wrapper for a StaplerResponse, e.g. in order to override some method.
@@ -139,9 +136,17 @@ public abstract class StaplerResponseWrapper implements StaplerResponse {
 
     /** {@inheritDoc} */
     @Override
+    @Deprecated
     public void serveExposedBean(StaplerRequest req, Object exposedBean, Flavor flavor)
             throws ServletException, IOException {
         getWrapped().serveExposedBean(req, exposedBean, flavor);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void serveExposedBean(StaplerRequest req, Object exposedBean, Flavor flavor, ExportConfig exportConfig)
+            throws ServletException, IOException {
+        getWrapped().serveExposedBean(req, exposedBean, flavor, exportConfig);
     }
 
     /** {@inheritDoc} */

--- a/core/src/main/java/org/kohsuke/stapler/StaplerResponseWrapper.java
+++ b/core/src/main/java/org/kohsuke/stapler/StaplerResponseWrapper.java
@@ -144,9 +144,9 @@ public abstract class StaplerResponseWrapper implements StaplerResponse {
 
     /** {@inheritDoc} */
     @Override
-    public void serveExposedBean(StaplerRequest req, Object exposedBean, Flavor flavor, ExportConfig exportConfig)
+    public void serveExposedBean(StaplerRequest req, Object exposedBean, ExportConfig exportConfig)
             throws ServletException, IOException {
-        getWrapped().serveExposedBean(req, exposedBean, flavor, exportConfig);
+        getWrapped().serveExposedBean(req, exposedBean, exportConfig);
     }
 
     /** {@inheritDoc} */

--- a/core/src/main/java/org/kohsuke/stapler/export/DataWriter.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/DataWriter.java
@@ -23,6 +23,7 @@
 
 package org.kohsuke.stapler.export;
 
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.lang.reflect.Type;
@@ -68,6 +69,8 @@ public interface DataWriter {
     void type(@Nullable Type expected, @Nullable Class actual) throws IOException;
     void startObject() throws IOException;
     void endObject() throws IOException;
+
+    @Nonnull ExportConfig getExportConfig();
 
     /**
      * Recommended property name to write out the 'type' parameter of {@link #type(Type,Class)}

--- a/core/src/main/java/org/kohsuke/stapler/export/ExportConfig.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/ExportConfig.java
@@ -1,38 +1,43 @@
 package org.kohsuke.stapler.export;
 
+import javax.annotation.Nonnull;
+
 /**
  * Controls the output behaviour.
  *
  * @author Kohsuke Kawaguchi
  */
 public class ExportConfig {
-    /**
-     * @deprecated
-     *      Use getter and setter
-     */
-    public boolean prettyPrint;
-
-    private ClassAttributeBehaviour classAttribute = ClassAttributeBehaviour.IF_NEEDED;
+    private final boolean prettyPrint;
+    private final ClassAttributeBehaviour classAttribute;
+    private final ExportInterceptor exportInterceptor;
+    private final boolean skipIfFail;
+    private final Flavor flavor;
 
     /**
-     * Interceptor used to check if given model object or it's property should be included in serialization
+     * Creates {@link ExportConfig} with a flavor
+     *
+     * @param flavor must be non-null
      */
-    private ExportInterceptor exportInterceptor = ExportInterceptor.DEFAULT;
-
-    private boolean skipIfFail = false;
-
-    public boolean isPrettyPrint() {
-        return prettyPrint;
+    private ExportConfig(Flavor flavor, ExportInterceptor exportInterceptor,
+                         ClassAttributeBehaviour classAttribute, boolean skipIfFail, boolean prettyPrint) {
+        this.flavor = flavor;
+        this.prettyPrint = prettyPrint;
+        this.classAttribute = (classAttribute == null) ? ClassAttributeBehaviour.IF_NEEDED.simple(): classAttribute;
+        this.exportInterceptor = exportInterceptor == null ? ExportInterceptor.DEFAULT :exportInterceptor;
+        this.skipIfFail = skipIfFail;
     }
 
     /**
      * If true, output will be indented to make it easier for humans to understand.
      */
-    public ExportConfig withPrettyPrint(boolean prettyPrint) {
-        this.prettyPrint = prettyPrint;
-        return this;
+    public boolean isPrettyPrint() {
+        return prettyPrint;
     }
 
+    /**
+     * Controls the behaviour of the class attribute to be produced.
+     */
     public ClassAttributeBehaviour getClassAttribute() {
         return classAttribute;
     }
@@ -40,27 +45,102 @@ public class ExportConfig {
     /**
      * Controls the behaviour of the class attribute to be produced.
      */
-    public ExportConfig withClassAttribute(ClassAttributeBehaviour cab) {
-        if (cab==null)  throw new NullPointerException();
-        this.classAttribute = cab;
-        return this;
+    public ClassAttributeBehaviour getClassAttributeBehaviour(){
+        return this.classAttribute;
     }
 
+    /**
+     * Gives {@link ExportInterceptor}. Always non-null.
+     */
     public ExportInterceptor getExportInterceptor() {
         return exportInterceptor;
     }
 
-    public ExportConfig withExportInterceptor(ExportInterceptor interceptor){
-        this.exportInterceptor = interceptor;
-        return this;
-    }
-
-    public ExportConfig withSkipIfFail(boolean skipIfFail){
-        this.skipIfFail = skipIfFail;
-        return this;
-    }
-
+    /**
+     *  Tells whether to skip serialization failure.
+     */
     public boolean isSkipIfFail() {
         return skipIfFail;
+    }
+
+    /**
+     * Gives {@link Flavor}. Always non-null.
+     */
+    public Flavor getFlavor() {
+        return flavor;
+    }
+
+    /**
+     * {@link ExportConfig} builder
+     */
+    public static class Builder{
+        private  boolean prettyPrint;
+
+        private  ClassAttributeBehaviour classAttribute = ClassAttributeBehaviour.IF_NEEDED;
+
+        private  ExportInterceptor exportInterceptor = ExportInterceptor.DEFAULT;
+
+        private  boolean skipIfFail = false;
+
+        private  final Flavor flavor;
+
+        public Builder(Flavor flavor){
+            this.flavor = flavor;
+        }
+
+        /**
+         * Turn on or off pretty printing of serialized data.
+         *
+         * @param prettyPrint default false.
+         *
+         * @return {@link Builder} instance
+         */
+        public Builder prettyPrint(boolean prettyPrint){
+            this.prettyPrint = prettyPrint;
+            return this;
+        }
+
+        /**
+         * If true serialization error will be ignored
+         *
+         * @param skipIfFail default false.
+         *
+         * @return {@link Builder} instance
+         */
+        public Builder skipIfFail(boolean skipIfFail){
+            this.skipIfFail = skipIfFail;
+            return this;
+        }
+
+        /**
+         * Control how _class attribute is written
+         *
+         * @param classAttribute default {@link ClassAttributeBehaviour#IF_NEEDED}.
+         *
+         * @return {@link Builder} instance
+         */
+        public Builder classAttribute(@Nonnull ClassAttributeBehaviour classAttribute){
+            this.classAttribute = classAttribute;
+            return this;
+        }
+
+        /**
+         * Controls serialization {@link @Exported} properties
+         *
+         * @param exportInterceptor default {@link ExportInterceptor#DEFAULT}.
+         *
+         * @return {@link Builder} instance
+         */
+        public Builder exportInterceptor(@Nonnull ExportInterceptor exportInterceptor){
+            this.exportInterceptor = exportInterceptor;
+            return this;
+        }
+
+        /**
+         * Builds and returns {@link ExportConfig}
+         */
+        public @Nonnull ExportConfig build(){
+            return new ExportConfig(flavor,exportInterceptor,classAttribute,skipIfFail,prettyPrint);
+        }
     }
 }

--- a/core/src/main/java/org/kohsuke/stapler/export/ExportConfig.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/ExportConfig.java
@@ -14,6 +14,13 @@ public class ExportConfig {
 
     private ClassAttributeBehaviour classAttribute = ClassAttributeBehaviour.IF_NEEDED;
 
+    /**
+     * Interceptor used to check if given model object or it's property should be included in serialization
+     */
+    private ExportInterceptor exportInterceptor = ExportInterceptor.DEFAULT;
+
+    private boolean skipIfFail = false;
+
     public boolean isPrettyPrint() {
         return prettyPrint;
     }
@@ -37,5 +44,23 @@ public class ExportConfig {
         if (cab==null)  throw new NullPointerException();
         this.classAttribute = cab;
         return this;
+    }
+
+    public ExportInterceptor getExportInterceptor() {
+        return exportInterceptor;
+    }
+
+    public ExportConfig withExportInterceptor(ExportInterceptor interceptor){
+        this.exportInterceptor = interceptor;
+        return this;
+    }
+
+    public ExportConfig withSkipIfFail(boolean skipIfFail){
+        this.skipIfFail = skipIfFail;
+        return this;
+    }
+
+    public boolean isSkipIfFail() {
+        return skipIfFail;
     }
 }

--- a/core/src/main/java/org/kohsuke/stapler/export/ExportConfig.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/ExportConfig.java
@@ -1,32 +1,24 @@
 package org.kohsuke.stapler.export;
 
-import javax.annotation.Nonnull;
-
 /**
  * Controls the output behaviour.
  *
  * @author Kohsuke Kawaguchi
  */
 public class ExportConfig {
-    private final boolean prettyPrint;
-    private final ClassAttributeBehaviour classAttribute;
-    private final ExportInterceptor exportInterceptor;
-    private final boolean skipIfFail;
-    private final Flavor flavor;
-
     /**
-     * Creates {@link ExportConfig} with a flavor
-     *
-     * @param flavor must be non-null
+     * @deprecated
+     *      Use getter and setter
      */
-    private ExportConfig(Flavor flavor, ExportInterceptor exportInterceptor,
-                         ClassAttributeBehaviour classAttribute, boolean skipIfFail, boolean prettyPrint) {
-        this.flavor = flavor;
-        this.prettyPrint = prettyPrint;
-        this.classAttribute = (classAttribute == null) ? ClassAttributeBehaviour.IF_NEEDED.simple(): classAttribute;
-        this.exportInterceptor = exportInterceptor == null ? ExportInterceptor.DEFAULT :exportInterceptor;
-        this.skipIfFail = skipIfFail;
-    }
+    public boolean prettyPrint;
+
+    private ClassAttributeBehaviour classAttribute = ClassAttributeBehaviour.IF_NEEDED;
+
+    private ExportInterceptor exportInterceptor = ExportInterceptor.DEFAULT;
+
+    private boolean skipIfFail = false;
+
+    private Flavor flavor = Flavor.JSON;
 
     /**
      * If true, output will be indented to make it easier for humans to understand.
@@ -36,8 +28,13 @@ public class ExportConfig {
     }
 
     /**
-     * Controls the behaviour of the class attribute to be produced.
+     * If true, output will be indented to make it easier for humans to understand.
      */
+    public ExportConfig withPrettyPrint(boolean prettyPrint) {
+        this.prettyPrint = prettyPrint;
+        return this;
+    }
+
     public ClassAttributeBehaviour getClassAttribute() {
         return classAttribute;
     }
@@ -45,102 +42,45 @@ public class ExportConfig {
     /**
      * Controls the behaviour of the class attribute to be produced.
      */
-    public ClassAttributeBehaviour getClassAttributeBehaviour(){
-        return this.classAttribute;
+    public ExportConfig withClassAttribute(ClassAttributeBehaviour cab) {
+        if (cab==null)  throw new NullPointerException();
+        this.classAttribute = cab;
+        return this;
     }
 
     /**
-     * Gives {@link ExportInterceptor}. Always non-null.
+     * Controls serialization of {@link @Exported} properties.
      */
     public ExportInterceptor getExportInterceptor() {
         return exportInterceptor;
     }
 
+    public ExportConfig withExportInterceptor(ExportInterceptor interceptor){
+        this.exportInterceptor = interceptor;
+        return this;
+    }
+
+    public ExportConfig withSkipIfFail(boolean skipIfFail){
+        this.skipIfFail = skipIfFail;
+        return this;
+    }
+
     /**
-     *  Tells whether to skip serialization failure.
+     * Turn on or off pretty printing of serialized data.
      */
     public boolean isSkipIfFail() {
         return skipIfFail;
     }
 
     /**
-     * Gives {@link Flavor}. Always non-null.
+     * Gives {@link Flavor}
      */
-    public Flavor getFlavor() {
+    public Flavor getFlavor(){
         return flavor;
     }
 
-    /**
-     * {@link ExportConfig} builder
-     */
-    public static class Builder{
-        private  boolean prettyPrint;
-
-        private  ClassAttributeBehaviour classAttribute = ClassAttributeBehaviour.IF_NEEDED;
-
-        private  ExportInterceptor exportInterceptor = ExportInterceptor.DEFAULT;
-
-        private  boolean skipIfFail = false;
-
-        private  final Flavor flavor;
-
-        public Builder(Flavor flavor){
-            this.flavor = flavor;
-        }
-
-        /**
-         * Turn on or off pretty printing of serialized data.
-         *
-         * @param prettyPrint default false.
-         *
-         * @return {@link Builder} instance
-         */
-        public Builder prettyPrint(boolean prettyPrint){
-            this.prettyPrint = prettyPrint;
-            return this;
-        }
-
-        /**
-         * If true serialization error will be ignored
-         *
-         * @param skipIfFail default false.
-         *
-         * @return {@link Builder} instance
-         */
-        public Builder skipIfFail(boolean skipIfFail){
-            this.skipIfFail = skipIfFail;
-            return this;
-        }
-
-        /**
-         * Control how _class attribute is written
-         *
-         * @param classAttribute default {@link ClassAttributeBehaviour#IF_NEEDED}.
-         *
-         * @return {@link Builder} instance
-         */
-        public Builder classAttribute(@Nonnull ClassAttributeBehaviour classAttribute){
-            this.classAttribute = classAttribute;
-            return this;
-        }
-
-        /**
-         * Controls serialization {@link @Exported} properties
-         *
-         * @param exportInterceptor default {@link ExportInterceptor#DEFAULT}.
-         *
-         * @return {@link Builder} instance
-         */
-        public Builder exportInterceptor(@Nonnull ExportInterceptor exportInterceptor){
-            this.exportInterceptor = exportInterceptor;
-            return this;
-        }
-
-        /**
-         * Builds and returns {@link ExportConfig}
-         */
-        public @Nonnull ExportConfig build(){
-            return new ExportConfig(flavor,exportInterceptor,classAttribute,skipIfFail,prettyPrint);
-        }
+    public ExportConfig withFlavor(Flavor flavor){
+        this.flavor = flavor;
+        return this;
     }
 }

--- a/core/src/main/java/org/kohsuke/stapler/export/ExportInterceptor.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/ExportInterceptor.java
@@ -16,22 +16,27 @@ public abstract class ExportInterceptor {
      * Subclasses must call {@link Property#getValue(Object)}  to retrieve the property.
      *
      * If the subclass decides the value can be included in the request return the value
-     * otherwise, return null to exclude.
+     * otherwise, return null results in to the property being written with value null.
      *
-     * @param property to get the value for
-     * @return the value of the property or null to exclude the property
+     * @param property to get the value from model object
+     * @param model object with this property
+     * @return the value of the property
      * @throws IOException if there was a problem with serialization that should prevent
      *         the serialization from proceeding
+     * @see Exported#skipNull()
      */
-    public abstract Object getValue(Property property, Object model) throws IOException;
+    public abstract Object getValue(Property property, Object model, ExportConfig config) throws IOException;
 
     public static final ExportInterceptor DEFAULT = new ExportInterceptor() {
         @Override
-        public Object getValue(Property property, Object model) throws IOException {
+        public Object getValue(Property property, Object model, ExportConfig config) throws IOException {
             try {
                 return property.getValue(model);
             } catch (IllegalAccessException | InvocationTargetException e) {
-                throw  new IOException("Failed to write " + property.name + ":"+e.getMessage(), e);
+                if(config.isSkipIfFail()) {
+                    return null;
+                }
+                throw new IOException("Failed to write " + property.name + ":" + e.getMessage(), e);
             }
         }
     };

--- a/core/src/main/java/org/kohsuke/stapler/export/ExportInterceptor.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/ExportInterceptor.java
@@ -13,14 +13,21 @@ import java.lang.reflect.InvocationTargetException;
  */
 public abstract class ExportInterceptor {
     /**
+     * Constant to tell if return of {@link ExportInterceptor#getValue(Property, Object, ExportConfig)} should be skipped.
+     *
+     * If Skip.TRUE then this property must be skipped.
+     */
+    public enum Skip {TRUE};
+
+    /**
      * Subclasses must call {@link Property#getValue(Object)}  to retrieve the property.
      *
      * If the subclass decides the value can be included in the request return the value
-     * otherwise, return null results in to the property being written with value null.
+     * otherwise, return {@link Skip#TRUE}  to skip the property.
      *
      * @param property to get the value from model object
      * @param model object with this property
-     * @return the value of the property
+     * @return the value of the property, if {@link Skip#TRUE} is returned, this property will be skipped
      * @throws IOException if there was a problem with serialization that should prevent
      *         the serialization from proceeding
      * @see Exported#skipNull()
@@ -34,7 +41,7 @@ public abstract class ExportInterceptor {
                 return property.getValue(model);
             } catch (IllegalAccessException | InvocationTargetException e) {
                 if(config.isSkipIfFail()) {
-                    return null;
+                    return Skip.TRUE;
                 }
                 throw new IOException("Failed to write " + property.name + ":" + e.getMessage(), e);
             }

--- a/core/src/main/java/org/kohsuke/stapler/export/ExportInterceptor.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/ExportInterceptor.java
@@ -4,21 +4,24 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 
 /**
- * Allows caller to intercept exporting of properties
+ * Allows caller to intercept exporting of properties.
+ *
+ * Implementation can choose to ignore properties in case of failure during serialization.
  *
  * @author Vivek Pandey
  * @author James Dumay
  */
 public abstract class ExportInterceptor {
     /**
-     * Subclasses must call {@link Property#getValue(Object)}  to retrieve the property
+     * Subclasses must call {@link Property#getValue(Object)}  to retrieve the property.
      *
      * If the subclass decides the value can be included in the request return the value
-     * otherwise, return null to exclude
+     * otherwise, return null to exclude.
      *
      * @param property to get the value for
      * @return the value of the property or null to exclude the property
-     * @throws IOException if there was a problem with serialization that should prevent the serialization from proceeding
+     * @throws IOException if there was a problem with serialization that should prevent
+     *         the serialization from proceeding
      */
     public abstract Object getValue(Property property, Object model) throws IOException;
 
@@ -28,7 +31,7 @@ public abstract class ExportInterceptor {
             try {
                 return property.getValue(model);
             } catch (IllegalAccessException | InvocationTargetException e) {
-                throw  new IOException("Failed to write " + property.name, e);
+                throw  new IOException("Failed to write " + property.name + ":"+e.getMessage(), e);
             }
         }
     };

--- a/core/src/main/java/org/kohsuke/stapler/export/ExportInterceptor.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/ExportInterceptor.java
@@ -15,19 +15,19 @@ public abstract class ExportInterceptor {
     /**
      * Constant to tell if return of {@link ExportInterceptor#getValue(Property, Object, ExportConfig)} should be skipped.
      *
-     * If Skip.TRUE then this property must be skipped.
+     * Constant to skip serializaing a property in case of error
      */
-    public enum Skip {TRUE};
+    public static final Object SKIP = new Object();
 
     /**
      * Subclasses must call {@link Property#getValue(Object)}  to retrieve the property.
      *
      * If the subclass decides the value can be included in the request return the value
-     * otherwise, return {@link Skip#TRUE}  to skip the property.
+     * otherwise, return {@link #SKIP}  to skip the property.
      *
      * @param property to get the value from model object
      * @param model object with this property
-     * @return the value of the property, if {@link Skip#TRUE} is returned, this property will be skipped
+     * @return the value of the property, if {@link #SKIP} is returned, this property will be skipped
      * @throws IOException if there was a problem with serialization that should prevent
      *         the serialization from proceeding
      * @see Exported#skipNull()
@@ -41,7 +41,7 @@ public abstract class ExportInterceptor {
                 return property.getValue(model);
             } catch (IllegalAccessException | InvocationTargetException e) {
                 if(config.isSkipIfFail()) {
-                    return Skip.TRUE;
+                    return SKIP;
                 }
                 throw new IOException("Failed to write " + property.name + ":" + e.getMessage(), e);
             }

--- a/core/src/main/java/org/kohsuke/stapler/export/ExportInterceptor.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/ExportInterceptor.java
@@ -1,0 +1,35 @@
+package org.kohsuke.stapler.export;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ * Allows caller to intercept exporting of properties
+ *
+ * @author Vivek Pandey
+ * @author James Dumay
+ */
+public abstract class ExportInterceptor {
+    /**
+     * Subclasses must call {@link Property#getValue(Object)}  to retrieve the property
+     *
+     * If the subclass decides the value can be included in the request return the value
+     * otherwise, return null to exclude
+     *
+     * @param property to get the value for
+     * @return the value of the property or null to exclude the property
+     * @throws IOException if there was a problem with serialization that should prevent the serialization from proceeding
+     */
+    public abstract Object getValue(Property property, Object model) throws IOException;
+
+    public static final ExportInterceptor DEFAULT = new ExportInterceptor() {
+        @Override
+        public Object getValue(Property property, Object model) throws IOException {
+            try {
+                return property.getValue(model);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                throw  new IOException("Failed to write " + property.name, e);
+            }
+        }
+    };
+}

--- a/core/src/main/java/org/kohsuke/stapler/export/FieldProperty.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/FieldProperty.java
@@ -25,7 +25,6 @@ package org.kohsuke.stapler.export;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Type;
-import java.io.IOException;
 
 /**
  * {@link Property} based on {@link Field}.
@@ -51,7 +50,7 @@ class FieldProperty extends Property {
         return parent.getJavadoc().getProperty(field.getName());
     }
 
-    protected Object getValue(Object object) throws IllegalAccessException {
+    public Object getValue(Object object) throws IllegalAccessException {
         return field.get(object);
     }
 }

--- a/core/src/main/java/org/kohsuke/stapler/export/Flavor.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Flavor.java
@@ -23,10 +23,10 @@
 
 package org.kohsuke.stapler.export;
 
-import org.kohsuke.stapler.StaplerResponse;
-
 import java.io.IOException;
 import java.io.Writer;
+
+import org.kohsuke.stapler.StaplerResponse;
 
 /**
  * Export flavor.
@@ -73,7 +73,7 @@ public enum Flavor {
         return createDataWriter(bean,rsp.getWriter());
     }
     public DataWriter createDataWriter(Object bean, Writer w) throws IOException {
-        return createDataWriter(bean,w,new ExportConfig.Builder(this).build());
+        return createDataWriter(bean,w,new ExportConfig().withFlavor(this));
     }
     public abstract DataWriter createDataWriter(Object bean, Writer w, ExportConfig config) throws IOException;
 }

--- a/core/src/main/java/org/kohsuke/stapler/export/Flavor.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Flavor.java
@@ -73,7 +73,7 @@ public enum Flavor {
         return createDataWriter(bean,rsp.getWriter());
     }
     public DataWriter createDataWriter(Object bean, Writer w) throws IOException {
-        return createDataWriter(bean,w,new ExportConfig());
+        return createDataWriter(bean,w,new ExportConfig.Builder(this).build());
     }
     public abstract DataWriter createDataWriter(Object bean, Writer w, ExportConfig config) throws IOException;
 }

--- a/core/src/main/java/org/kohsuke/stapler/export/JSONDataWriter.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/JSONDataWriter.java
@@ -23,6 +23,7 @@
 
 package org.kohsuke.stapler.export;
 
+import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.Writer;
 import java.lang.reflect.Type;
@@ -44,6 +45,11 @@ class JSONDataWriter implements DataWriter {
         this.out = out;
         this.config = config;
         indent = config.isPrettyPrint() ? 0 : -1;
+    }
+
+    @Override
+    public @Nonnull ExportConfig getExportConfig() {
+        return config;
     }
 
     public void name(String name) throws IOException {

--- a/core/src/main/java/org/kohsuke/stapler/export/MethodProperty.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/MethodProperty.java
@@ -67,7 +67,7 @@ final class MethodProperty extends Property {
         return parent.getJavadoc().getProperty(method.getName()+"()");
     }
 
-    protected Object getValue(Object object) throws IllegalAccessException, InvocationTargetException {
+    public Object getValue(Object object) throws IllegalAccessException, InvocationTargetException {
         try {
             return handle.invoke(object);
         } catch (Throwable throwable) {

--- a/core/src/main/java/org/kohsuke/stapler/export/Model.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Model.java
@@ -23,11 +23,6 @@
 
 package org.kohsuke.stapler.export;
 
-import com.google.common.base.Predicate;
-import org.kohsuke.stapler.export.TreePruner.ByDepth;
-
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
@@ -41,6 +36,12 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
+
+import com.google.common.base.Predicate;
+import org.kohsuke.stapler.export.TreePruner.ByDepth;
 
 /**
  * Writes all the property of one {@link ExportedBean} to {@link DataWriter}.

--- a/core/src/main/java/org/kohsuke/stapler/export/Model.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Model.java
@@ -23,6 +23,11 @@
 
 package org.kohsuke.stapler.export;
 
+import com.google.common.base.Predicate;
+import org.kohsuke.stapler.export.TreePruner.ByDepth;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
@@ -36,12 +41,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
-
-import com.google.common.base.Predicate;
-import org.kohsuke.stapler.export.TreePruner.ByDepth;
 
 /**
  * Writes all the property of one {@link ExportedBean} to {@link DataWriter}.

--- a/core/src/main/java/org/kohsuke/stapler/export/Property.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Property.java
@@ -133,7 +133,7 @@ public abstract class Property implements Comparable<Property> {
 
         Object d = writer.getExportConfig().getExportInterceptor().getValue(this,object, writer.getExportConfig());
 
-        if ((d==null && skipNull) || d == ExportInterceptor.Skip.TRUE) { // don't write anything
+        if ((d==null && skipNull) || d == ExportInterceptor.SKIP) { // don't write anything
             return;
         }
         if (merge) {

--- a/core/src/main/java/org/kohsuke/stapler/export/Property.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Property.java
@@ -133,7 +133,7 @@ public abstract class Property implements Comparable<Property> {
 
         Object d = writer.getExportConfig().getExportInterceptor().getValue(this,object, writer.getExportConfig());
 
-        if (d==null && skipNull) { // don't write anything
+        if ((d==null && skipNull) || d == ExportInterceptor.Skip.TRUE) { // don't write anything
             return;
         }
         if (merge) {

--- a/core/src/main/java/org/kohsuke/stapler/export/Property.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Property.java
@@ -131,7 +131,7 @@ public abstract class Property implements Comparable<Property> {
         TreePruner child = pruner.accept(object, this);
         if (child==null)        return;
 
-        Object d = safeGetValue(object, writer.getExportConfig().getExportInterceptor());
+        Object d = writer.getExportConfig().getExportInterceptor().getValue(this,object);
 
         if (d==null && skipNull) { // don't write anything
             return;
@@ -154,13 +154,6 @@ public abstract class Property implements Comparable<Property> {
             writer.name(name);
             writeValue(type, d, child, writer);
         }
-    }
-
-    /**
-     *  Ignores property if {@link ExportInterceptor#getValue(Property, Object)} throws NotExportableException.
-     */
-    private Object safeGetValue(Object o, ExportInterceptor interceptor) throws IOException {
-        return interceptor.getValue(this,o);
     }
 
     /**

--- a/core/src/main/java/org/kohsuke/stapler/export/Property.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Property.java
@@ -23,10 +23,6 @@
 
 package org.kohsuke.stapler.export;
 
-import org.jvnet.tiger_types.Types;
-import org.kohsuke.stapler.export.TreePruner.ByDepth;
-
-import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.lang.reflect.InvocationTargetException;
@@ -42,6 +38,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+import javax.annotation.Nonnull;
+
+import org.jvnet.tiger_types.Types;
+import org.kohsuke.stapler.export.TreePruner.ByDepth;
 
 /**
  * Exposes one {@link Exported exposed property} of {@link ExportedBean} to
@@ -131,7 +131,7 @@ public abstract class Property implements Comparable<Property> {
         TreePruner child = pruner.accept(object, this);
         if (child==null)        return;
 
-        Object d = writer.getExportConfig().getExportInterceptor().getValue(this,object);
+        Object d = writer.getExportConfig().getExportInterceptor().getValue(this,object, writer.getExportConfig());
 
         if (d==null && skipNull) { // don't write anything
             return;

--- a/core/src/main/java/org/kohsuke/stapler/export/XMLDataWriter.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/XMLDataWriter.java
@@ -26,6 +26,7 @@ package org.kohsuke.stapler.export;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerResponse;
 
+import javax.annotation.Nonnull;
 import java.lang.reflect.Type;
 import java.util.Stack;
 import java.io.Writer;
@@ -49,6 +50,7 @@ final class XMLDataWriter implements DataWriter {
     private final Writer out;
     private ExportConfig config;
     private String classAttr;
+    private final ExportConfig exportConfig;
 
     XMLDataWriter(Object bean, Writer out, ExportConfig config) throws IOException {
         Class c=bean.getClass();
@@ -58,11 +60,17 @@ final class XMLDataWriter implements DataWriter {
         this.out = out;
         this.config = config;
         this.isArray.push(false);
+        this.exportConfig = config;
         // TODO: support pretty printing
     }
 
     XMLDataWriter(Object bean, StaplerResponse rsp, ExportConfig config) throws IOException {
         this(bean,rsp.getWriter(),config);
+    }
+
+    @Override
+    public @Nonnull ExportConfig getExportConfig() {
+        return exportConfig;
     }
 
     public void name(String name) {

--- a/core/src/test/java/org/kohsuke/stapler/export/ClassAttributeBehaviourTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/ClassAttributeBehaviourTest.java
@@ -14,8 +14,8 @@ import static org.junit.Assert.*;
  */
 public class ClassAttributeBehaviourTest {
 
-    private ExportConfig config = new ExportConfig()
-            .withClassAttribute(ClassAttributeBehaviour.IF_NEEDED.simple());
+    private ExportConfig config = new ExportConfig.Builder(Flavor.JSON)
+            .classAttribute(ClassAttributeBehaviour.IF_NEEDED.simple()).build();
 
     private <T> String write(T bean) throws IOException {
         StringWriter w = new StringWriter();

--- a/core/src/test/java/org/kohsuke/stapler/export/ClassAttributeBehaviourTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/ClassAttributeBehaviourTest.java
@@ -1,21 +1,20 @@
 package org.kohsuke.stapler.export;
 
-import org.junit.Test;
-
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.junit.Assert.*;
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author Kohsuke Kawaguchi
  */
 public class ClassAttributeBehaviourTest {
 
-    private ExportConfig config = new ExportConfig.Builder(Flavor.JSON)
-            .classAttribute(ClassAttributeBehaviour.IF_NEEDED.simple()).build();
+    private ExportConfig config = new ExportConfig()
+            .withClassAttribute(ClassAttributeBehaviour.IF_NEEDED.simple());
 
     private <T> String write(T bean) throws IOException {
         StringWriter w = new StringWriter();

--- a/core/src/test/java/org/kohsuke/stapler/export/JSONDataWriterTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/JSONDataWriterTest.java
@@ -10,8 +10,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 public class JSONDataWriterTest {
-    private ExportConfig config = new ExportConfig()
-            .withClassAttribute(ClassAttributeBehaviour.IF_NEEDED.simple());
+    private ExportConfig config = new ExportConfig.Builder(Flavor.JSON).classAttribute(ClassAttributeBehaviour.IF_NEEDED.simple()).build();
 
     private <T> String serialize(T bean, Class<T> clazz) throws IOException {
         StringWriter w = new StringWriter();

--- a/core/src/test/java/org/kohsuke/stapler/export/JSONDataWriterTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/JSONDataWriterTest.java
@@ -1,16 +1,15 @@
 package org.kohsuke.stapler.export;
 
-import org.junit.Test;
-
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.List;
 
+import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 public class JSONDataWriterTest {
-    private ExportConfig config = new ExportConfig.Builder(Flavor.JSON).classAttribute(ClassAttributeBehaviour.IF_NEEDED.simple()).build();
+    private ExportConfig config = new ExportConfig().withFlavor(Flavor.JSON).withClassAttribute(ClassAttributeBehaviour.IF_NEEDED.simple());
 
     private <T> String serialize(T bean, Class<T> clazz) throws IOException {
         StringWriter w = new StringWriter();

--- a/core/src/test/java/org/kohsuke/stapler/export/ModelTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/ModelTest.java
@@ -36,8 +36,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 
 public class ModelTest {
-    private ExportConfig config = new ExportConfig()
-            .withClassAttribute(ClassAttributeBehaviour.ALWAYS.simple());
+    private ExportConfig config = new ExportConfig.Builder(Flavor.JSON).classAttribute(ClassAttributeBehaviour.ALWAYS.simple()).build();
     ModelBuilder builder = new ModelBuilder();
 
     @Test // JENKINS-26775
@@ -158,8 +157,7 @@ public class ModelTest {
 
     @Test
     public void testNotExportedBean() throws IOException {
-        ExportConfig config = new ExportConfig();
-        config.withExportInterceptor(new ExportInterceptor1()).withSkipIfFail(true);
+        ExportConfig config = new ExportConfig.Builder(Flavor.JSON).exportInterceptor(new ExportInterceptor1()).skipIfFail(true).build();
         StringWriter writer = new StringWriter();
         ExportableBean b = new ExportableBean();
         builder.get(ExportableBean.class).writeTo(b,Flavor.JSON.createDataWriter(b, writer, config));
@@ -170,8 +168,7 @@ public class ModelTest {
     // should fail when serializing getShouldBeSkippedAsNull()
     @Test(expected = IOException.class)
     public void testNotExportedBeanFailing() throws IOException {
-        ExportConfig config = new ExportConfig();
-        config.withExportInterceptor(new ExportInterceptor2()).withSkipIfFail(true);
+        ExportConfig config = new ExportConfig.Builder(Flavor.JSON).exportInterceptor(new ExportInterceptor2()).skipIfFail(true).build();
         StringWriter writer = new StringWriter();
         ExportableBean b = new ExportableBean();
         builder.get(ExportableBean.class).writeTo(b,Flavor.JSON.createDataWriter(b, writer, config));

--- a/core/src/test/java/org/kohsuke/stapler/export/ModelTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/ModelTest.java
@@ -130,7 +130,7 @@ public class ModelTest {
     public static class ExportInterceptor1 extends ExportInterceptor{
 
         @Override
-        public Object getValue(Property property, Object model) throws IOException {
+        public Object getValue(Property property, Object model, ExportConfig config) throws IOException {
             try {
                 return property.getValue(model);
             } catch (IllegalAccessException | InvocationTargetException | NotExportableException e) {
@@ -142,7 +142,7 @@ public class ModelTest {
     public static class ExportInterceptor2 extends ExportInterceptor{
 
         @Override
-        public Object getValue(Property property, Object model) throws IOException {
+        public Object getValue(Property property, Object model, ExportConfig config) throws IOException {
             try {
                 return property.getValue(model);
             } catch (IllegalAccessException | InvocationTargetException | NotExportableException e) {

--- a/core/src/test/java/org/kohsuke/stapler/export/ModelTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/ModelTest.java
@@ -135,7 +135,7 @@ public class ModelTest {
                 return property.getValue(model);
             } catch (IllegalAccessException | InvocationTargetException | NotExportableException e) {
                 if(property.name.equals("shouldBeSkipped")){
-                    return Skip.TRUE;
+                    return SKIP;
                 }
                 throw new IOException(e);
             }
@@ -152,7 +152,7 @@ public class ModelTest {
                 if(!property.getType().isAssignableFrom(NotExportedBean.class)){
                     throw new IOException("Failed to write "+property.name);
                 }
-                return Skip.TRUE; //skip failing property
+                return SKIP; //skip failing property
             }
         }
     }

--- a/core/src/test/java/org/kohsuke/stapler/export/ModelTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/ModelTest.java
@@ -23,9 +23,6 @@
  */
 package org.kohsuke.stapler.export;
 
-import org.junit.Assert;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.io.StringWriter;
 import java.lang.reflect.InvocationTargetException;
@@ -33,10 +30,12 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
+import org.junit.Assert;
+import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 public class ModelTest {
-    private ExportConfig config = new ExportConfig.Builder(Flavor.JSON).classAttribute(ClassAttributeBehaviour.ALWAYS.simple()).build();
+    private ExportConfig config = new ExportConfig().withFlavor(Flavor.JSON).withClassAttribute(ClassAttributeBehaviour.ALWAYS.simple());
     ModelBuilder builder = new ModelBuilder();
 
     @Test // JENKINS-26775
@@ -157,7 +156,7 @@ public class ModelTest {
 
     @Test
     public void testNotExportedBean() throws IOException {
-        ExportConfig config = new ExportConfig.Builder(Flavor.JSON).exportInterceptor(new ExportInterceptor1()).skipIfFail(true).build();
+        ExportConfig config = new ExportConfig().withFlavor(Flavor.JSON).withExportInterceptor(new ExportInterceptor1()).withSkipIfFail(true);
         StringWriter writer = new StringWriter();
         ExportableBean b = new ExportableBean();
         builder.get(ExportableBean.class).writeTo(b,Flavor.JSON.createDataWriter(b, writer, config));
@@ -168,7 +167,7 @@ public class ModelTest {
     // should fail when serializing getShouldBeSkippedAsNull()
     @Test(expected = IOException.class)
     public void testNotExportedBeanFailing() throws IOException {
-        ExportConfig config = new ExportConfig.Builder(Flavor.JSON).exportInterceptor(new ExportInterceptor2()).skipIfFail(true).build();
+        ExportConfig config = new ExportConfig().withFlavor(Flavor.JSON).withExportInterceptor(new ExportInterceptor2()).withSkipIfFail(true);
         StringWriter writer = new StringWriter();
         ExportableBean b = new ExportableBean();
         builder.get(ExportableBean.class).writeTo(b,Flavor.JSON.createDataWriter(b, writer, config));

--- a/core/src/test/java/org/kohsuke/stapler/export/NamedPathPrunerTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/NamedPathPrunerTest.java
@@ -1,14 +1,14 @@
 package org.kohsuke.stapler.export;
 
-import junit.framework.TestCase;
-
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.List;
 
+import junit.framework.TestCase;
+
 public class NamedPathPrunerTest extends TestCase {
 
-    private static ExportConfig config = new ExportConfig.Builder(Flavor.JSON).classAttribute(ClassAttributeBehaviour.IF_NEEDED.simple()).build();
+    private static ExportConfig config = new ExportConfig().withFlavor(Flavor.JSON).withClassAttribute(ClassAttributeBehaviour.IF_NEEDED.simple());
 
     public NamedPathPrunerTest(String name) {
         super(name);

--- a/core/src/test/java/org/kohsuke/stapler/export/NamedPathPrunerTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/NamedPathPrunerTest.java
@@ -1,13 +1,14 @@
 package org.kohsuke.stapler.export;
 
+import junit.framework.TestCase;
+
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.List;
-import junit.framework.TestCase;
 
 public class NamedPathPrunerTest extends TestCase {
 
-    private static ExportConfig config = new ExportConfig().withClassAttribute(ClassAttributeBehaviour.IF_NEEDED.simple());
+    private static ExportConfig config = new ExportConfig.Builder(Flavor.JSON).classAttribute(ClassAttributeBehaviour.IF_NEEDED.simple()).build();
 
     public NamedPathPrunerTest(String name) {
         super(name);

--- a/core/src/test/java/org/kohsuke/stapler/export/XMLDataWriterTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/XMLDataWriterTest.java
@@ -17,7 +17,7 @@ import java.util.Iterator;
 import java.util.List;
 
 public class XMLDataWriterTest extends TestCase {
-    private ExportConfig config = new ExportConfig().withClassAttribute(ClassAttributeBehaviour.IF_NEEDED.simple());
+    private ExportConfig config = new ExportConfig.Builder(Flavor.XML).classAttribute(ClassAttributeBehaviour.IF_NEEDED.simple()).build();
 
     public XMLDataWriterTest(String n) {
         super(n);

--- a/core/src/test/java/org/kohsuke/stapler/export/XMLDataWriterTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/XMLDataWriterTest.java
@@ -1,13 +1,5 @@
 package org.kohsuke.stapler.export;
 
-import com.google.common.collect.ImmutableList;
-import junit.framework.TestCase;
-import org.junit.Test;
-import org.xml.sax.InputSource;
-import org.xml.sax.helpers.DefaultHandler;
-
-import javax.xml.parsers.SAXParser;
-import javax.xml.parsers.SAXParserFactory;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
@@ -15,9 +7,17 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
+
+import com.google.common.collect.ImmutableList;
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.xml.sax.InputSource;
+import org.xml.sax.helpers.DefaultHandler;
 
 public class XMLDataWriterTest extends TestCase {
-    private ExportConfig config = new ExportConfig.Builder(Flavor.XML).classAttribute(ClassAttributeBehaviour.IF_NEEDED.simple()).build();
+    private ExportConfig config = new ExportConfig().withFlavor(Flavor.XML).withClassAttribute(ClassAttributeBehaviour.IF_NEEDED.simple());
 
     public XMLDataWriterTest(String n) {
         super(n);


### PR DESCRIPTION
This PR bring customization feature where plugins like blueocean can configure stapler and participate during property serialization and decide whether to fail or skip serialization. 

Implementation is pretty much based on @i386 [proposal](https://docs.google.com/document/d/1AalzfYZ0HDfwtFMUNaw_okWMLaaQ0S5Q1o6L4taevL4/edit#heading=h.vr11cprbtd0) sent at dev list some time back. Further this custom serialization approach is followup of [PR 89](https://github.com/stapler/stapler/pull/89#issuecomment-272307140) to fix it in generic way.