### PR TITLE
Handle CustomExportedBean serialization with Exported.merge=true

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/export/Model.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Model.java
@@ -23,6 +23,11 @@
 
 package org.kohsuke.stapler.export;
 
+import com.google.common.base.Predicate;
+import org.kohsuke.stapler.export.TreePruner.ByDepth;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Field;
@@ -36,12 +41,6 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import javax.annotation.CheckForNull;
-import javax.annotation.Nullable;
-
-import com.google.common.base.Predicate;
-import org.kohsuke.stapler.export.TreePruner.ByDepth;
 
 /**
  * Writes all the property of one {@link ExportedBean} to {@link DataWriter}.

--- a/core/src/main/java/org/kohsuke/stapler/export/Property.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Property.java
@@ -135,7 +135,8 @@ public abstract class Property implements Comparable<Property> {
         if (d==null && skipNull) { // don't write anything
             return;
         }
-        if (merge) {
+        //Merge doesn't apply to CustomExportedBean, so skip it
+        if (merge && !(d instanceof CustomExportedBean)) {
             // merged property will get all its properties written here
             if (d != null) {
                 Model model = owner.get(d.getClass(), parent.type, name);

--- a/core/src/test/java/org/kohsuke/stapler/export/ModelTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/ModelTest.java
@@ -23,14 +23,16 @@
  */
 package org.kohsuke.stapler.export;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.Assert;
+import org.junit.Test;
 
+import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 public class ModelTest {
     private ExportConfig config = new ExportConfig()
@@ -120,5 +122,29 @@ public class ModelTest {
 
         @Exported(skipNull=false)
         public String ddd = "ddd";
+    }
+
+    // CustomExportedBean test
+    @ExportedBean
+    public static final class Build{
+        @Exported(merge = true)
+        public Result getBuildResult(){
+            return new Result();
+        }
+    }
+
+    public static class Result implements CustomExportedBean{
+        @Override
+        public Object toExportedObject() {
+            return "SUCCESS";
+        }
+    }
+
+    @Test
+    public void customExportedBeanTest() throws IOException {
+        Build buildData = new Build();
+        StringWriter sw = new StringWriter();
+        builder.get(Build.class).writeTo(buildData, Flavor.JSON.createDataWriter(buildData, sw, config));
+        Assert.assertEquals("{\"_class\":\"Build\",\"buildResult\":\"SUCCESS\"}", sw.toString());
     }
 }


### PR DESCRIPTION
CustomExportedBean serialization fails when a CustomExportedBean property is merged with @Exported(merge=true).

This was reported in https://issues.jenkins-ci.org/browse/JENKINS-41806.

```
org.kohsuke.stapler.export.NotExportableException: class org.kohsuke.stapler.export.ModelTest$Result doesn't have @ExportedBean so cannot write org.kohsuke.stapler.export.ModelTest$Build.buildResult

  at org.kohsuke.stapler.export.Model.<init>(Model.java:78)
  at org.kohsuke.stapler.export.ModelBuilder.get(ModelBuilder.java:51)
  at org.kohsuke.stapler.export.Property.writeTo(Property.java:141)
  at org.kohsuke.stapler.export.Model.writeNestedObjectTo(Model.java:226)
  at org.kohsuke.stapler.export.Model.writeTo(Model.java:197)
  at org.kohsuke.stapler.export.Model.writeTo(Model.java:217)
  at org.kohsuke.stapler.export.Model.writeTo(Model.java:181)
```