### PR TITLE
Quietly ignore interfaces in IndexHtmlDispatcher, avoiding NPE.

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/IndexHtmlDispatcher.java
+++ b/core/src/main/java/org/kohsuke/stapler/IndexHtmlDispatcher.java
@@ -33,7 +33,10 @@ class IndexHtmlDispatcher extends Dispatcher {
     }
 
     /**
-     * Returns a {@link IndexHtmlDispatcher} if and only if the said class has {@code index.html} as a side-file
+     * Returns a {@link IndexHtmlDispatcher} if and only if the said class has {@code index.html} as a side-file.
+     * @param context
+     * @param c Class from where to start the index.html inspection. Will go through class hierarchy (unless interface)
+     * @return Index dispatcher or {@code null} if it cannot be found
      */
     static Dispatcher make(ServletContext context, Class c) {
         for (; c != null && c != Object.class; c = c.getSuperclass()) {

--- a/core/src/main/java/org/kohsuke/stapler/IndexHtmlDispatcher.java
+++ b/core/src/main/java/org/kohsuke/stapler/IndexHtmlDispatcher.java
@@ -36,7 +36,7 @@ class IndexHtmlDispatcher extends Dispatcher {
      * Returns a {@link IndexHtmlDispatcher} if and only if the said class has {@code index.html} as a side-file
      */
     static Dispatcher make(ServletContext context, Class c) {
-        for (; c != Object.class; c = c.getSuperclass()) {
+        for (; c != null && c != Object.class; c = c.getSuperclass()) {
             String name = "/WEB-INF/side-files/" + c.getName().replace('.', '/') + "/index.html";
             try {
                 URL url = context.getResource(name);

--- a/core/src/test/java/org/kohsuke/stapler/IndexHtmlDispatcherTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/IndexHtmlDispatcherTest.java
@@ -1,0 +1,24 @@
+package org.kohsuke.stapler;
+
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+
+import javax.servlet.ServletContext;
+import java.net.MalformedURLException;
+
+import static org.mockito.Mockito.*;
+
+public class IndexHtmlDispatcherTest {
+
+    @Test
+    @Issue("#109")
+    public void ignoreInterfaces() throws MalformedURLException {
+        ServletContext context = mock(ServletContext.class);
+        when(context.getResource(any(String.class))).thenReturn(null);
+
+        IndexHtmlDispatcher.make(context, TestInterface.class);
+    }
+
+    private interface TestInterface {}
+
+}

--- a/core/src/test/java/org/kohsuke/stapler/IndexHtmlDispatcherTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/IndexHtmlDispatcherTest.java
@@ -6,6 +6,7 @@ import org.jvnet.hudson.test.Issue;
 import javax.servlet.ServletContext;
 import java.net.MalformedURLException;
 
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.*;
 
 public class IndexHtmlDispatcherTest {
@@ -16,7 +17,7 @@ public class IndexHtmlDispatcherTest {
         ServletContext context = mock(ServletContext.class);
         when(context.getResource(any(String.class))).thenReturn(null);
 
-        IndexHtmlDispatcher.make(context, TestInterface.class);
+        assertNull(IndexHtmlDispatcher.make(context, TestInterface.class));
     }
 
     private interface TestInterface {}


### PR DESCRIPTION
[Issue #109](https://github.com/stapler/stapler/issues/109)

Interfaces do not have a superclass and thus a NPE exception was happening.

@reviewbybees @jglick @oleg-nenashev 