### PR TITLE
JENKINS-40979  NPE where child can be null

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/export/FilteringTreePruner.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/FilteringTreePruner.java
@@ -25,7 +25,7 @@ class FilteringTreePruner extends TreePruner {
 
         // for merge properties, the current restrictions on the property names should
         // still apply to the child TreePruner
-        if (prop.merge)
+        if (prop.merge && child != null)
             child = new FilteringTreePruner(predicate,child);
 
         return child;


### PR DESCRIPTION
Discovered that in certain conditions `child` can be null and cause an NPE https://github.com/jenkinsci/blueocean-plugin/pull/996 