### PR TITLE
Verifying that web methods may be defined as default interface methods

### DIFF
--- a/core/src/test/java/org/kohsuke/stapler/DispatcherTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DispatcherTest.java
@@ -238,7 +238,24 @@ public class DispatcherTest extends JettyTestCase {
         assertEquals("POST: Hello\n", p.getContent());
     }
 
-
+    public void testInterfaceMethods() throws Exception {
+        assertEquals("default", new WebClient().getPage(new URL(url, "usesInterfaceMethods/foo")).getWebResponse().getContentAsString().trim());
+        assertEquals("overridden", new WebClient().getPage(new URL(url, "overridesInterfaceMethods/foo")).getWebResponse().getContentAsString().trim());
+    }
+    public interface InterfaceWithWebMethods {
+        default HttpResponse doFoo() {
+            return HttpResponses.plainText("default");
+        }
+    }
+    public class UsesInterfaceMethods implements InterfaceWithWebMethods {}
+    public class OverridesInterfaceMethods implements InterfaceWithWebMethods {
+        @Override
+        public HttpResponse doFoo() {
+            return HttpResponses.plainText("overridden");
+        }
+    }
+    public final UsesInterfaceMethods usesInterfaceMethods = new UsesInterfaceMethods();
+    public final OverridesInterfaceMethods overridesInterfaceMethods = new OverridesInterfaceMethods();
 
     //===================================================================
 

--- a/core/src/test/java/org/kohsuke/stapler/DispatcherTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DispatcherTest.java
@@ -239,10 +239,24 @@ public class DispatcherTest extends JettyTestCase {
     }
 
     public void testInterfaceMethods() throws Exception {
-        assertEquals("default", new WebClient().getPage(new URL(url, "usesInterfaceMethods/foo")).getWebResponse().getContentAsString().trim());
-        assertEquals("overridden", new WebClient().getPage(new URL(url, "overridesInterfaceMethods/foo")).getWebResponse().getContentAsString().trim());
+        WebClient wc = new WebClient();
+        try {
+            wc.getPage(new URL(url, "usesInterfaceMethods/foo"));
+            fail();
+        } catch (FailingHttpStatusCodeException x) {
+            assertEquals(HttpServletResponse.SC_METHOD_NOT_ALLOWED, x.getStatusCode());
+        }
+        assertEquals("default", wc.getPage(new WebRequestSettings(new URL(url, "usesInterfaceMethods/foo"), HttpMethod.POST)).getWebResponse().getContentAsString().trim());
+        try {
+            wc.getPage(new URL(url, "overridesInterfaceMethods/foo"));
+            fail();
+        } catch (FailingHttpStatusCodeException x) {
+            assertEquals(HttpServletResponse.SC_METHOD_NOT_ALLOWED, x.getStatusCode());
+        }
+        assertEquals("due to UnionAnnotatedElement it is even inherited", "overridden", wc.getPage(new WebRequestSettings(new URL(url, "overridesInterfaceMethods/foo"), HttpMethod.POST)).getWebResponse().getContentAsString().trim());
     }
     public interface InterfaceWithWebMethods {
+        @RequirePOST
         default HttpResponse doFoo() {
             return HttpResponses.plainText("default");
         }

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <java.level>7</java.level>
+    <java.level>8</java.level>
   </properties>
 
   <build>


### PR DESCRIPTION
Relevant since Jenkins core is now on `-source 8`.

@reviewbybees