### PR TITLE
Update Apache Commons Fileupload version to 1.3.2

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>stapler-parent</artifactId>
     <version>1.251-SNAPSHOT</version>
   </parent>
-  
+
   <artifactId>stapler</artifactId>
   <name>Stapler</name>
   <description>Stapler HTTP request handling engine</description>
@@ -97,8 +97,8 @@
       <!-- perhaps mark this dependency optional? -->
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
-      <version>1.2.1</version>
-    </dependency>    
+      <version>1.3.2</version>
+    </dependency>
     <!-- optional REST support -->
     <dependency>
       <groupId>com.sun.xml.txw2</groupId>
@@ -157,4 +157,3 @@
     </dependency>
   </dependencies>
 </project>
-

--- a/core/src/test/java/org/kohsuke/stapler/MockRequest.java
+++ b/core/src/test/java/org/kohsuke/stapler/MockRequest.java
@@ -34,6 +34,9 @@ public class MockRequest implements HttpServletRequest {
     }
 
     public String getHeader(String name) {
+        if ("Content-length".equals(name)) {
+            return "0";
+        }
         // TODO
         throw new UnsupportedOperationException();
     }


### PR DESCRIPTION
To include fixes for CVE-2014-0050, CVE-2013-0248 and CVE-2016-3092