### PR TITLE
Make ClassDescriptor deterministic

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/ClassDescriptor.java
+++ b/core/src/main/java/org/kohsuke/stapler/ClassDescriptor.java
@@ -150,7 +150,17 @@ public final class ClassDescriptor {
         Arrays.sort(declaredMethods, new Comparator<Method>() {
             @Override
             public int compare(Method m1, Method m2) {
-                return m1.toString().compareTo(m2.toString());
+                boolean m1d = m1.getAnnotation(Deprecated.class) != null;
+                boolean m2d = m2.getAnnotation(Deprecated.class) != null;
+                if (m1d && !m2d) {
+                    // Prefer nondeprecated to deprecated.
+                    return 1;
+                } else if (!m1d && m2d) {
+                    return -1;
+                } else {
+                    // Sort by string representation, so for example doFoo() is preferred to doFoo(StaplerRequest, StaplerResponse).
+                    return m1.toString().compareTo(m2.toString());
+                }
             }
         });
         for (Method m : declaredMethods) {

--- a/core/src/main/java/org/kohsuke/stapler/ClassDescriptor.java
+++ b/core/src/main/java/org/kohsuke/stapler/ClassDescriptor.java
@@ -42,8 +42,9 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -84,7 +85,7 @@ public final class ClassDescriptor {
         findMethods(clazz,clazz,methods,new HashSet<Class>());
 
         // organize them into groups
-        Map<Signature,List<Method>> groups = new HashMap<Signature, List<Method>>();
+        Map<Signature,List<Method>> groups = new LinkedHashMap<>();
         for (MethodMirror m : methods) {
             List<Method> v = groups.get(m.sig);
             if (v==null)    groups.put(m.sig, v=new ArrayList<Method>());
@@ -145,7 +146,14 @@ public final class ClassDescriptor {
         if (sc!=null)
             findMethods(sc,Types.getBaseClass(logical,sc),result,visited);
 
-        for (Method m : c.getDeclaredMethods()) {
+        Method[] declaredMethods = c.getDeclaredMethods();
+        Arrays.sort(declaredMethods, new Comparator<Method>() {
+            @Override
+            public int compare(Method m1, Method m2) {
+                return m1.toString().compareTo(m2.toString());
+            }
+        });
+        for (Method m : declaredMethods) {
             if (m.isBridge())    continue;
             if ((m.getModifiers() & Modifier.PUBLIC)!=0) {
                 java.lang.reflect.Type[] paramTypes = m.getGenericParameterTypes();

--- a/core/src/test/java/org/kohsuke/stapler/DispatcherTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DispatcherTest.java
@@ -273,6 +273,29 @@ public class DispatcherTest extends JettyTestCase {
         assertEquals(1, requirePostOnBase.hit);
     }
 
+    public void testOverloads() throws Exception {
+        TextPage p = new WebClient().getPage(new URL(url, "overloaded/x"));
+        assertEquals("doX()", p.getContent().trim());
+    }
+    public final Object overloaded = new Overloaded();
+    public static class Overloaded {
+        public HttpResponse doX() {
+            return HttpResponses.plainText("doX()");
+        }
+        public HttpResponse doX(StaplerRequest req) {
+            return HttpResponses.plainText("doX(StaplerRequest)");
+        }
+        public HttpResponse doX(StaplerResponse rsp) {
+            return HttpResponses.plainText("doX(StaplerResponse)");
+        }
+        public HttpResponse doX(StaplerRequest req, StaplerResponse rsp) {
+            return HttpResponses.plainText("doX(StaplerRequest, StaplerResponse)");
+        }
+        @WebMethod(name = "x")
+        public HttpResponse x() {
+            return HttpResponses.plainText("x()");
+        }
+    }
 
     public final TestWithPublicField testWithPublicField = new TestWithPublicField();
 

--- a/core/src/test/java/org/kohsuke/stapler/DispatcherTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DispatcherTest.java
@@ -275,10 +275,11 @@ public class DispatcherTest extends JettyTestCase {
 
     public void testOverloads() throws Exception {
         TextPage p = new WebClient().getPage(new URL(url, "overloaded/x"));
-        assertEquals("doX()", p.getContent().trim());
+        assertEquals("doX(StaplerRequest)", p.getContent().trim());
     }
     public final Object overloaded = new Overloaded();
     public static class Overloaded {
+        @Deprecated
         public HttpResponse doX() {
             return HttpResponses.plainText("doX()");
         }


### PR DESCRIPTION
Has sometimes been observed that a web method with multiple overloads will randomly run one or the other (according to JVM implementation details), which is confusing and can lead to bugs, especially if all but one overload was intentionally deprecated. This patch simply picks one nondeprecated overload consistently so there are no surprises (as in https://github.com/junit-team/junit4/pull/293 for example).

@reviewbybees