### PR TITLE
[STAPLER-121] Initial proposed consolidated annotations for Stapler

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/ClassDescriptor.java
+++ b/core/src/main/java/org/kohsuke/stapler/ClassDescriptor.java
@@ -51,6 +51,8 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.logging.Logger;
+import org.kohsuke.stapler.annotations.StaplerObject;
+import org.kohsuke.stapler.annotations.StaplerPath;
 
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.WARNING;
@@ -97,10 +99,22 @@ public final class ClassDescriptor {
         for (List<Method> m : groups.values()) {
             if (m.size()==1) {
                 Method one = m.get(0);
+                if (StaplerObject.Helper.isObject(one.getDeclaringClass())) {
+                    // ignore functions from a stapler object if they do not have a @StaplerPath
+                    if (!StaplerPath.Helper.isPath(one)) {
+                        continue;
+                    }
+                }
                 functions.add(new Function.InstanceFunction(one)
                         .wrapByInterceptors(one));
             } else {
                 Collections.reverse(m);
+                if (StaplerObject.Helper.isObject(m.get(0).getDeclaringClass())) {
+                    // ignore functions from a stapler object if they do not have a @StaplerPath
+                    if (!StaplerPath.Helper.isPath(m.get(0))) {
+                        continue;
+                    }
+                }
                 functions.add(new Function.OverridingInstanceFunction(m)
                         .wrapByInterceptors(new UnionAnnotatedElement(m)));
             }

--- a/core/src/main/java/org/kohsuke/stapler/FunctionList.java
+++ b/core/src/main/java/org/kohsuke/stapler/FunctionList.java
@@ -24,7 +24,11 @@
 package org.kohsuke.stapler;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
 import java.util.*;
+import org.kohsuke.stapler.annotations.StaplerMethod;
+import org.kohsuke.stapler.annotations.StaplerPath;
+import org.kohsuke.stapler.annotations.StaplerRMI;
 
 /**
  * Immutable list of {@link Function}s.
@@ -32,6 +36,7 @@ import java.util.*;
  * @author Kohsuke Kawaguchi
  */
 public final class FunctionList extends AbstractList<Function> {
+    private static final FunctionList EMPTY = new FunctionList();
     private final Function[] functions;
 
     public FunctionList(Function... functions) {
@@ -67,6 +72,10 @@ public final class FunctionList extends AbstractList<Function> {
         combined.addAll(Arrays.asList(this.functions));
         combined.addAll(Arrays.asList(that.functions));
         return new FunctionList(combined);
+    }
+
+    public static FunctionList emptyList() {
+        return EMPTY;
     }
 
     //public int length() {
@@ -133,6 +142,78 @@ public final class FunctionList extends AbstractList<Function> {
         return filter(new Filter() {
             public boolean keep(Function m) {
                 return m.getName().startsWith("do") || m.getAnnotation(WebMethod.class)!=null;
+            }
+        });
+    }
+
+    /**
+     * Returns {@link Function}s that have {@link StaplerPath.Helper#isPath(Function)} true.
+     */
+    public FunctionList staplerPath() {
+        return filter(new Filter() {
+            @Override
+            public boolean keep(Function m) {
+                return StaplerPath.Helper.isPath(m);
+            }
+        });
+    }
+
+    /**
+     * Returns {@link Function}s that have {@link StaplerPath.Helper#isPath(Function)} false.
+     */
+    public FunctionList nonStaplerPath() {
+        return filter(new Filter() {
+            @Override
+            public boolean keep(Function m) {
+                return !StaplerPath.Helper.isPath(m);
+            }
+        });
+    }
+
+    /**
+     * Returns {@link Function}s that have {@link StaplerMethod.Helper#isMethod(Function)} true.
+     */
+    public FunctionList staplerMethod() {
+        return filter(new Filter() {
+            @Override
+            public boolean keep(Function m) {
+                return StaplerMethod.Helper.isMethod(m);
+            }
+        });
+    }
+
+    /**
+     * Returns {@link Function}s that have {@link StaplerMethod.Helper#isMethod(Function)} false.
+     */
+    public FunctionList nonStaplerMethod() {
+        return filter(new Filter() {
+            @Override
+            public boolean keep(Function m) {
+                return !StaplerMethod.Helper.isMethod(m);
+            }
+        });
+    }
+
+    /**
+     * Returns {@link Function}s that have {@link StaplerRMI}.
+     */
+    public FunctionList staplerRmi() {
+        return filter(new Filter() {
+            @Override
+            public boolean keep(Function m) {
+                return m.getAnnotation(StaplerRMI.class) != null;
+            }
+        });
+    }
+
+    /**
+     * Returns {@link Function}s that do not have {@link StaplerRMI}.
+     */
+    public FunctionList nonStaplerRmi() {
+        return filter(new Filter() {
+            @Override
+            public boolean keep(Function m) {
+                return m.getAnnotation(StaplerRMI.class) == null;
             }
         });
     }

--- a/core/src/main/java/org/kohsuke/stapler/MetaClass.java
+++ b/core/src/main/java/org/kohsuke/stapler/MetaClass.java
@@ -23,6 +23,7 @@
 
 package org.kohsuke.stapler;
 
+import java.lang.annotation.Annotation;
 import net.sf.json.JSONArray;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.stapler.annotations.StaplerObject;
@@ -106,7 +107,14 @@ public class MetaClass extends TearOffSupport {
         this.dispatchers.clear();
         KlassDescriptor<?> node = new KlassDescriptor(klass);
         // TODO abstract this test into Klass so that e.g. Ruby can have idiomatic
-        boolean staplerObject = clazz.getAnnotation(StaplerObject.class) != null;
+        boolean staplerObject = false;
+        // TODO use clazz.getDeclaredAnnotation(StaplerObject.class) != null when Java 8 baseline
+        for (Annotation o: clazz.getDeclaredAnnotations()) {
+            if (o instanceof StaplerObject) {
+                staplerObject = true;
+                break;
+            }
+        }
 
         dispatchers.add(new DirectoryishDispatcher());
 

--- a/core/src/main/java/org/kohsuke/stapler/MetaClass.java
+++ b/core/src/main/java/org/kohsuke/stapler/MetaClass.java
@@ -115,7 +115,7 @@ public class MetaClass extends TearOffSupport {
 
         FunctionList staplerPaths = node.methods.staplerPath();
         FunctionList impliedPaths;
-        if (clazz.getAnnotation(StaplerObject.class) != null) {
+        if (staplerObject) {
             impliedPaths = FunctionList.emptyList();
         } else {
             impliedPaths = node.methods.nonStaplerPath();

--- a/core/src/main/java/org/kohsuke/stapler/StaplerFacetDispatcher.java
+++ b/core/src/main/java/org/kohsuke/stapler/StaplerFacetDispatcher.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nonnull;
+import javax.servlet.ServletException;
+import org.kohsuke.stapler.annotations.StaplerFacet;
+
+/**
+ * Wraps a {@link Facet} dispatcher with a guard to ensure that only {@link StaplerFacet} approved facets are
+ * dispatched.
+ *
+ * @since TODO.
+ */
+public class StaplerFacetDispatcher extends Dispatcher {
+    /**
+     * The {@link Dispatcher} that we are guarding.
+     */
+    @Nonnull
+    private final Dispatcher delegate;
+    /**
+     * The approved facet names.
+     */
+    @Nonnull
+    private final Set<String> names;
+
+    /**
+     * Constructor.
+     *
+     * @param delegate the delegate.
+     * @param names    the approved names.
+     */
+    private StaplerFacetDispatcher(@Nonnull Dispatcher delegate, @Nonnull Set<String> names) {
+        this.delegate = delegate;
+        this.names = names;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean dispatch(RequestImpl req, ResponseImpl rsp, Object node)
+            throws IOException, ServletException, IllegalAccessException, InvocationTargetException {
+        // check Jelly view
+        String next = req.tokens.peek();
+        if (next == null) {
+            return false;
+        }
+        // only allow the guarded views
+        if (!names.contains(next)) {
+            return false;
+        }
+        return delegate.dispatch(req, rsp, node);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String toString() {
+        return delegate.toString();
+    }
+
+    /**
+     * Guards the supplied {@link Dispatcher} using the supplied {@link StaplerFacet} details.
+     *
+     * @param dispatcher the {@link Dispatcher} to guard.
+     * @param facets     the allowed {@link StaplerFacet}s.
+     * @return a guarded {@link Dispatcher}.
+     */
+    @Nonnull
+    public static Dispatcher guard(@Nonnull Dispatcher dispatcher, @Nonnull List<StaplerFacet> facets) {
+        Set<String> names = new HashSet<>();
+        for (StaplerFacet facet : facets) {
+            names.add(facet.value());
+        }
+        return new StaplerFacetDispatcher(dispatcher, names);
+    }
+
+    /**
+     * Guards the supplied {@link Dispatcher}s using the supplied {@link StaplerFacet} details.
+     *
+     * @param dispatchers the {@link Dispatcher}s to guard.
+     * @param facets      the allowed {@link StaplerFacet}s.
+     * @return a guarded {@link Dispatcher}.
+     */
+    @Nonnull
+    public static List<Dispatcher> guard(@Nonnull List<Dispatcher> dispatchers, @Nonnull List<StaplerFacet> facets) {
+        if (dispatchers.isEmpty()) {
+            return Collections.emptyList();
+        }
+        List<Dispatcher> wrapped = new ArrayList<>(dispatchers.size());
+        Set<String> names = new HashSet<>();
+        for (StaplerFacet facet : facets) {
+            names.add(facet.value());
+        }
+        for (Dispatcher dispatcher : dispatchers) {
+            wrapped.add(new StaplerFacetDispatcher(dispatcher, names));
+        }
+        return wrapped;
+    }
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerBinder.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerBinder.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotates a static public factory method that will be used to instantiate objects of the defining class when that
+ * class is used as a parameter type on a {@link StaplerMethod} (or on another {@link StaplerBinder}).
+ * A class may only have one {@link StaplerBinder}
+ * <p>
+ * Example:
+ * <pre>
+ * {@code @StaplerObject}
+ * public class Widget {
+ *    {@code @StaplerBinder}
+ *     public static Widget create(StaplerRequest req) {
+ *         return ...;
+ *     }
+ * }</pre>
+ * Then if there is an action method that needs the required type the factory method will be invoked prior to the
+ * action method being invoked.
+ * <pre>
+ * {@code @StaplerObject}
+ * public class Root {
+ *    {@code @StaplerGET}
+ *     public HttpResponse doSomething(Widget widget) {
+ *         ...
+ *     }
+ * }
+ * </pre>
+ * <strong>NOTE: there are no protections against recursive {@link StaplerBinder} call trees.</strong>
+ */
+@Target(METHOD)
+@Retention(RUNTIME)
+@Documented
+public @interface StaplerBinder {
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerCONNECT.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerCONNECT.java
@@ -40,7 +40,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
-@StaplerPath.Implicit
+@StaplerPath.Implicit(methodPrefix = "do")
 @InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
 public @interface StaplerCONNECT {
 }

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerCONNECT.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerCONNECT.java
@@ -40,6 +40,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
+@StaplerPath.Implicit
 @InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
 public @interface StaplerCONNECT {
 }

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerCONNECT.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerCONNECT.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.kohsuke.stapler.interceptor.InterceptorAnnotation;
+import org.kohsuke.stapler.interceptor.Stage;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Shorthand annotation equivalent to {@link StaplerMethod} with {@code CONNECT}.
+ *
+ * @since TODO
+ */
+@Target(METHOD)
+@Retention(RUNTIME)
+@Documented
+@InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
+public @interface StaplerCONNECT {
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerContent.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerContent.java
@@ -43,6 +43,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Documented
 @Repeatable(StaplerContents.class)
+@StaplerPath.Implicit
 @InterceptorAnnotation(value = StaplerContentInterceptor.class, stage = Stage.SELECTION)
 public @interface StaplerContent {
     /**

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerContent.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerContent.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import javax.servlet.http.HttpServletRequest;
+import org.kohsuke.stapler.interceptor.InterceptorAnnotation;
+import org.kohsuke.stapler.interceptor.Stage;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation that restricts {@link StaplerMethod} matching based on the {@code Content-Type} header.
+ *
+ * @since TODO
+ */
+@Target(METHOD)
+@Retention(RUNTIME)
+@Documented
+@Repeatable(StaplerContents.class)
+@InterceptorAnnotation(value = StaplerContentInterceptor.class, stage = Stage.SELECTION)
+public @interface StaplerContent {
+    /**
+     * Constant to match any text content type.
+     */
+    String ANY_TEXT = "text/*";
+
+    /**
+     * The {@link HttpServletRequest#getContentType()} to match (charset encoding ignored)
+     *
+     * @return The {@link HttpServletRequest#getContentType()} to match (charset encoding ignored).
+     */
+    String value();
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerContent.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerContent.java
@@ -43,7 +43,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Documented
 @Repeatable(StaplerContents.class)
-@StaplerPath.Implicit
+@StaplerPath.Implicit(methodPrefix = "do")
 @InterceptorAnnotation(value = StaplerContentInterceptor.class, stage = Stage.SELECTION)
 public @interface StaplerContent {
     /**

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerContentInterceptor.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerContentInterceptor.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import javax.servlet.ServletException;
+import org.apache.commons.lang.StringUtils;
+import org.kohsuke.stapler.CancelRequestHandlingException;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.interceptor.Interceptor;
+
+/**
+ * A {@link Interceptor} that processes {@link StaplerContent} and {@link StaplerContents} annotations to restrict
+ * {@link StaplerMethod} matching to the subset with matching {@code Content-Type} header.
+ *
+ * @since TODO
+ */
+public class StaplerContentInterceptor extends Interceptor {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Object invoke(StaplerRequest request, StaplerResponse response, Object instance, Object[] arguments)
+            throws IllegalAccessException,
+            InvocationTargetException, ServletException {
+        if (matches(request)) {
+            return target.invoke(request, response, instance, arguments);
+        } else {
+            throw new CancelRequestHandlingException();
+        }
+    }
+
+    private boolean matches(StaplerRequest request) {
+        String contentType = StringUtils.defaultString(request.getContentType());
+        int index = contentType.indexOf(';');
+        contentType = index == -1 ? contentType.trim() : contentType.substring(0, index).trim();
+
+        index = contentType.indexOf('/');
+        for (Annotation a : target.getAnnotations()) {
+            if (a instanceof StaplerContents) {
+                for (StaplerContent sa : ((StaplerContents) a).value()) {
+                    String ct = sa.value();
+                    if (ct.equals(contentType)) {
+                        return true;
+                    }
+                    if (ct.equals("*/*")) {
+                        return true;
+                    }
+                    if (index != -1 && ct.startsWith("*/")
+                            && ct.substring(1).equals(contentType.substring(index))) {
+                        return true;
+                    }
+                    if (index != -1 && ct.endsWith("/*")
+                            && ct.substring(0, ct.length() - 2).equals(contentType.substring(0, index))) {
+                        return true;
+                    }
+                }
+            } else if (a instanceof StaplerContent) {
+                // need to check for a single annotation to cover the case where the class was compiled with Java < 8
+                String ct = ((StaplerContent) a).value();
+                if (ct.equals(contentType)) {
+                    return true;
+                }
+                if (ct.equals("*/*")) {
+                    return true;
+                }
+                if (index != -1 && ct.startsWith("*/")
+                        && ct.substring(1).equals(contentType.substring(index))) {
+                    return true;
+                }
+                if (index != -1 && ct.endsWith("/*")
+                        && ct.substring(0, ct.length() - 2).equals(contentType.substring(0, index))) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerContents.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerContents.java
@@ -41,6 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
+@StaplerPath.Implicit
 @InterceptorAnnotation(value = StaplerContentInterceptor.class, stage = Stage.SELECTION)
 public @interface StaplerContents {
     StaplerContent[] value();

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerContents.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerContents.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.kohsuke.stapler.WebMethod;
+import org.kohsuke.stapler.interceptor.InterceptorAnnotation;
+import org.kohsuke.stapler.interceptor.Stage;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * A container annotation for multiple {@link StaplerContent} annotations.
+ *
+ * @since TODO
+ */
+@Target(METHOD)
+@Retention(RUNTIME)
+@Documented
+@InterceptorAnnotation(value = StaplerContentInterceptor.class, stage = Stage.SELECTION)
+public @interface StaplerContents {
+    StaplerContent[] value();
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerContents.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerContents.java
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
-@StaplerPath.Implicit
+@StaplerPath.Implicit(methodPrefix = "do")
 @InterceptorAnnotation(value = StaplerContentInterceptor.class, stage = Stage.SELECTION)
 public @interface StaplerContents {
     StaplerContent[] value();

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerDELETE.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerDELETE.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.kohsuke.stapler.interceptor.InterceptorAnnotation;
+import org.kohsuke.stapler.interceptor.Stage;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Shorthand annotation equivalent to {@link StaplerMethod} with {@code DELETE}.
+ *
+ * @since TODO
+ */
+@Target(METHOD)
+@Retention(RUNTIME)
+@Documented
+@InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
+public @interface StaplerDELETE {
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerDELETE.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerDELETE.java
@@ -40,6 +40,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
+@StaplerPath.Implicit
 @InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
 public @interface StaplerDELETE {
 }

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerDELETE.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerDELETE.java
@@ -40,7 +40,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
-@StaplerPath.Implicit
+@StaplerPath.Implicit(methodPrefix = "do")
 @InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
 public @interface StaplerDELETE {
 }

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerFacet.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerFacet.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.kohsuke.stapler.Facet;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation to document that the class expects there to be a {@link Facet} with the specified name available.
+ * If the annotated type is either an {@code interface} or an {@code abstract class} then the {@link Facet} is
+ * not required available to the annotated class but must be present on any concrete implementation subclasses.
+ *
+ * @since TODO
+ */
+@Target(TYPE)
+@Retention(RUNTIME)
+@Documented
+@Repeatable(StaplerFacets.class)
+@Inherited
+public @interface StaplerFacet {
+    /**
+     * The name of the {@link Facet} excluding the extension, for example {@code index} not {@code index.jelly} or
+     * {@code index.groovy}.
+     *
+     * @return the name of the {@link Facet}.
+     */
+    String value();
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerFacets.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerFacets.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * A container annotation for multiple {@link StaplerFacet} annotations.
+ *
+ * @since TODO
+ */
+@Target(TYPE)
+@Retention(RUNTIME)
+@Documented
+@Inherited
+public @interface StaplerFacets {
+    StaplerFacet[] value();
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerFragment.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerFragment.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.kohsuke.stapler.AbstractTearOff;
+import org.kohsuke.stapler.Facet;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation to document that the class expects there to be a {@link AbstractTearOff} with the specified name available.
+ * If the annotation is not {@link #optional()} and the annotated type is either an {@code interface} or an
+ * {@code abstract class} then the {@link AbstractTearOff} is not required available to the annotated class but must be
+ * present on any concrete implementation subclasses.
+ *
+ * @since TODO
+ */
+@Target(TYPE)
+@Retention(RUNTIME)
+@Documented
+@Repeatable(StaplerFragments.class)
+@Inherited
+public @interface StaplerFragment {
+    /**
+     * The name of the {@link AbstractTearOff} excluding the {@link AbstractTearOff#getDefaultScriptExtension()}, for
+     * example {@code config} not {@code config.jelly} or {@code config.groovy}.
+     *
+     * @return the name of the {@link AbstractTearOff}.
+     */
+    String value();
+
+    /**
+     * Marks the {@link AbstractTearOff} as optional.
+     * @return {@code true} if the {@link AbstractTearOff} is optional.
+     */
+    boolean optional() default false;
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerFragments.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerFragments.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * A container annotation for multiple {@link StaplerFragment} annotations.
+ *
+ * @since TODO
+ */
+@Target(TYPE)
+@Retention(RUNTIME)
+@Documented
+@Inherited
+public @interface StaplerFragments {
+    StaplerFragment[] value();
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerGET.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerGET.java
@@ -40,7 +40,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
-@StaplerPath.Implicit
+@StaplerPath.Implicit(methodPrefix = "do")
 @InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
 public @interface StaplerGET {
 }

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerGET.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerGET.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.kohsuke.stapler.interceptor.InterceptorAnnotation;
+import org.kohsuke.stapler.interceptor.Stage;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Shorthand annotation equivalent to {@link StaplerMethod} with {@code GET}.
+ *
+ * @since TODO
+ */
+@Target(METHOD)
+@Retention(RUNTIME)
+@Documented
+@InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
+public @interface StaplerGET {
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerGET.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerGET.java
@@ -40,6 +40,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
+@StaplerPath.Implicit
 @InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
 public @interface StaplerGET {
 }

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerHEAD.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerHEAD.java
@@ -40,7 +40,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
-@StaplerPath.Implicit
+@StaplerPath.Implicit(methodPrefix = "do")
 @InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
 public @interface StaplerHEAD {
 }

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerHEAD.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerHEAD.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.kohsuke.stapler.interceptor.InterceptorAnnotation;
+import org.kohsuke.stapler.interceptor.Stage;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Shorthand annotation equivalent to {@link StaplerMethod} with {@code HEAD}.
+ *
+ * @since TODO
+ */
+@Target(METHOD)
+@Retention(RUNTIME)
+@Documented
+@InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
+public @interface StaplerHEAD {
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerHEAD.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerHEAD.java
@@ -40,6 +40,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
+@StaplerPath.Implicit
 @InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
 public @interface StaplerHEAD {
 }

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerMethod.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerMethod.java
@@ -37,6 +37,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Retention(RUNTIME)
 @Documented
 @Repeatable(StaplerMethods.class)
+@StaplerPath.Implicit
 @InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
 public @interface StaplerMethod {
     String value();

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerMethod.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerMethod.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.kohsuke.stapler.interceptor.InterceptorAnnotation;
+import org.kohsuke.stapler.interceptor.Stage;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target(METHOD)
+@Retention(RUNTIME)
+@Documented
+@Repeatable(StaplerMethods.class)
+@InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
+public @interface StaplerMethod {
+    String value();
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerMethod.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerMethod.java
@@ -55,7 +55,7 @@ public @interface StaplerMethod {
     String value();
 
     /**
-     * Helper class that consolidates the rules for determining the names to infer from a
+     * Helper class that consolidates the rules for determining if a method is a valid stapler method.
      */
     class Helper {
 

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerMethodInterceptor.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerMethodInterceptor.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import javax.servlet.ServletException;
+import org.kohsuke.stapler.CancelRequestHandlingException;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.interceptor.Interceptor;
+import org.kohsuke.stapler.interceptor.InterceptorAnnotation;
+
+public class StaplerMethodInterceptor extends Interceptor {
+    @Override
+    public Object invoke(StaplerRequest request, StaplerResponse response, Object instance, Object[] arguments)
+            throws IllegalAccessException,
+            InvocationTargetException, ServletException {
+        if (matches(request)) {
+            return target.invoke(request, response, instance, arguments);
+        } else {
+            throw new CancelRequestHandlingException();
+        }
+    }
+
+    private boolean matches(StaplerRequest request) {
+        String method = request.getMethod();
+        String override = request.getHeader("X-HTTP-Method-Override");
+        if (override != null) {
+            method = override;
+        }
+
+        for (Annotation a : target.getAnnotations()) {
+            if (a instanceof StaplerMethods) {
+                for (StaplerMethod sa : ((StaplerMethods) a).value()) {
+                    if (sa.value().equals(method)) {
+                        return true;
+                    }
+                }
+            } else if (a instanceof StaplerMethod) {
+                if (((StaplerMethod) a).value().equals(method)) {
+                    return true;
+                }
+            } else {
+                Class<? extends Annotation> t = a.annotationType();
+                InterceptorAnnotation ia = t.getAnnotation(InterceptorAnnotation.class);
+                if (ia != null && ia.value() == StaplerMethodInterceptor.class) {
+                    if (t.getSimpleName().equals("Stapler" + method)) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    }
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerMethodInterceptor.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerMethodInterceptor.java
@@ -54,12 +54,14 @@ public class StaplerMethodInterceptor extends Interceptor {
         for (Annotation a : target.getAnnotations()) {
             if (a instanceof StaplerMethods) {
                 for (StaplerMethod sa : ((StaplerMethods) a).value()) {
-                    if (sa.value().equals(method)) {
+                    String value = sa.value();
+                    if (value.equals(method) || value.equals(StaplerMethod.ALL)) {
                         return true;
                     }
                 }
             } else if (a instanceof StaplerMethod) {
-                if (((StaplerMethod) a).value().equals(method)) {
+                String value = ((StaplerMethod) a).value();
+                if (value.equals(method) || value.equals(StaplerMethod.ALL)) {
                     return true;
                 }
             } else {

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerMethods.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerMethods.java
@@ -41,6 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
+@StaplerPath.Implicit
 @InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
 public @interface StaplerMethods {
     StaplerMethod[] value();

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerMethods.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerMethods.java
@@ -41,7 +41,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
-@StaplerPath.Implicit
+@StaplerPath.Implicit(methodPrefix = "do")
 @InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
 public @interface StaplerMethods {
     StaplerMethod[] value();

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerMethods.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerMethods.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.kohsuke.stapler.WebMethod;
+import org.kohsuke.stapler.interceptor.InterceptorAnnotation;
+import org.kohsuke.stapler.interceptor.Stage;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Restricts a {@link WebMethod} to a specific HTTP method 'StaplerGET'.
+ *
+ * @author Kohsuke Kawaguchi
+ */
+@Target(METHOD)
+@Retention(RUNTIME)
+@Documented
+@InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
+public @interface StaplerMethods {
+    StaplerMethod[] value();
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerObject.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerObject.java
@@ -31,9 +31,25 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
+/**
+ * Marker annotation that declares the annotated type is complete from the point of view of
+ * {@link org.kohsuke.stapler.annotations}{@code .Stapler*} annotations. A type that is complete can be subjected to
+ * additional verifications.
+ *
+ * @since TODO
+ */
+/* FIXME: Need to determine how inheritance applies to this annotation.
+ *
+ * Some of the issues:
+ * * If a class is annotated, it does not seem appropriate that all derived classes inherit the annotation as they
+ *   may have been compiled against an earlier version of the class (from before these annotations were introduced)
+ *   thus we need to find a way to differentiate between a class that has been explicitly annotated and one
+ *   that has "inherited" the annotation.
+ * * Similarly, in terms of completeness, that concept only apply at the annotated level.
+ */
 @Target(TYPE)
 @Retention(RUNTIME)
 @Documented
-@Inherited
+@Inherited // TODO determine whether this should be inherited or not
 public @interface StaplerObject {
 }

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerObject.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerObject.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target(TYPE)
+@Retention(RUNTIME)
+@Documented
+@Inherited
+public @interface StaplerObject {
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerObject.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerObject.java
@@ -35,21 +35,17 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * Marker annotation that declares the annotated type is complete from the point of view of
  * {@link org.kohsuke.stapler.annotations}{@code .Stapler*} annotations. A type that is complete can be subjected to
  * additional verifications.
+ * <h2>Inheritance</h2>
+ * When a class is annotated with {@link StaplerObject} it means that everything defined in that class is definitive.
+ * Methods defined in a superclass that is not {@link StaplerObject} annotated will only require annotations if they
+ * are overridden in the {@link StaplerObject} annotated class.
+ * Methods defined in a subclass will only require annotations if that subclass is also {@link StaplerObject} annotated.
  *
  * @since TODO
- */
-/* FIXME: Need to determine how inheritance applies to this annotation.
- *
- * Some of the issues:
- * * If a class is annotated, it does not seem appropriate that all derived classes inherit the annotation as they
- *   may have been compiled against an earlier version of the class (from before these annotations were introduced)
- *   thus we need to find a way to differentiate between a class that has been explicitly annotated and one
- *   that has "inherited" the annotation.
- * * Similarly, in terms of completeness, that concept only apply at the annotated level.
  */
 @Target(TYPE)
 @Retention(RUNTIME)
 @Documented
-@Inherited // TODO determine whether this should be inherited or not
+@Inherited // TODO determine whether this should be inherited or not (in meta-class we use getDeclaredAnnotations for check)
 public @interface StaplerObject {
 }

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPATCH.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPATCH.java
@@ -40,6 +40,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
+@StaplerPath.Implicit
 @InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
 public @interface StaplerPATCH {
 }

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPATCH.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPATCH.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.kohsuke.stapler.interceptor.InterceptorAnnotation;
+import org.kohsuke.stapler.interceptor.Stage;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Shorthand annotation equivalent to {@link StaplerMethod} with {@code PATCH}.
+ *
+ * @since TODO
+ */
+@Target(METHOD)
+@Retention(RUNTIME)
+@Documented
+@InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
+public @interface StaplerPATCH {
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPATCH.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPATCH.java
@@ -40,7 +40,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
-@StaplerPath.Implicit
+@StaplerPath.Implicit(methodPrefix = "do")
 @InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
 public @interface StaplerPATCH {
 }

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPOST.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPOST.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.kohsuke.stapler.interceptor.InterceptorAnnotation;
+import org.kohsuke.stapler.interceptor.Stage;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Shorthand annotation equivalent to {@link StaplerMethod} with {@code POST}.
+ *
+ * @since TODO
+ */
+@Target(METHOD)
+@Retention(RUNTIME)
+@Documented
+@InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
+public @interface StaplerPOST {
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPOST.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPOST.java
@@ -40,6 +40,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
+@StaplerPath.Implicit
 @InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
 public @interface StaplerPOST {
 }

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPOST.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPOST.java
@@ -40,7 +40,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
-@StaplerPath.Implicit
+@StaplerPath.Implicit(methodPrefix = "do")
 @InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
 public @interface StaplerPOST {
 }

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPUT.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPUT.java
@@ -40,6 +40,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
+@StaplerPath.Implicit
 @InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
 public @interface StaplerPUT {
 }

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPUT.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPUT.java
@@ -40,7 +40,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target(METHOD)
 @Retention(RUNTIME)
 @Documented
-@StaplerPath.Implicit
+@StaplerPath.Implicit(methodPrefix = "do")
 @InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
 public @interface StaplerPUT {
 }

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPUT.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPUT.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import org.kohsuke.stapler.interceptor.InterceptorAnnotation;
+import org.kohsuke.stapler.interceptor.Stage;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Shorthand annotation equivalent to {@link StaplerMethod} with {@code PUT}.
+ *
+ * @since TODO
+ */
+@Target(METHOD)
+@Retention(RUNTIME)
+@Documented
+@InterceptorAnnotation(value = StaplerMethodInterceptor.class, stage = Stage.SELECTION)
+public @interface StaplerPUT {
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPath.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPath.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Marks methods and fields as being navigable by Stapler.
+ */
+@Target({METHOD, FIELD})
+@Retention(RUNTIME)
+@Documented
+@Repeatable(StaplerPaths.class)
+public @interface StaplerPath {
+    /**
+     * Special constant used to signify that the annotated method is a catch-all dynamic match.
+     */
+    String DYNAMIC = "\u0000\ufefforg.kohsuke.stapler.annotations.StaplerPath#DYNAMIC\ufeff\u0000";
+    /**
+     * Special constant used to signify that the path segment should be inferred from the method name:
+     * <ul>
+     * <li>Method names starting with {@code get} will have the {@code get} removed and the next character turned to
+     * lowercase</li>
+     * <li>Method names starting with {@code do} will have the {@code do} removed and the next character turned to
+     * lowercase</li>
+     * <li>Method names starting with {@code js} will have the {@code js} removed and the next character turned to
+     * lowercase</li>
+     * <li>All other methods will be ignored (annotation processor should flag such methods as incorrectly annotated)
+     * </li>
+     * <li>Field names will be used verbatim</li>
+     * </ul>
+     */
+    String INFER_FROM_NAME = "\u0000\ufefforg.kohsuke.stapler.annotations.StaplerPath#INFER\ufeff\u0000";
+    /**
+     * Special constant used to signify that the path segment should be treated as the "index" page
+     * (which also matches an empty segment)
+     */
+    String INDEX = "";
+
+    String value() default INFER_FROM_NAME;
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPath.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPath.java
@@ -28,12 +28,15 @@ import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
  * Marks methods and fields as being navigable by Stapler.
+ *
+ * @since TODO
  */
 @Target({METHOD, FIELD})
 @Retention(RUNTIME)
@@ -66,4 +69,14 @@ public @interface StaplerPath {
     String INDEX = "";
 
     String value() default INFER_FROM_NAME;
+
+    /**
+     * Meta-annotation to flag an annotation as implying {@link StaplerPath#INFER_FROM_NAME} without explicitly
+     * requiring the method / field to have a {@link StaplerPath} annotation
+     */
+    @Target(ANNOTATION_TYPE)
+    @Retention(RUNTIME)
+    @Documented
+    public @interface Implicit {
+    }
 }

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPath.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPath.java
@@ -97,7 +97,7 @@ public @interface StaplerPath {
     }
 
     /**
-     * Helper class that consolidates the rules for determining the names to infer from a
+     * Helper class that consolidates the rules for determining the names to infer from a method
      */
     class Helper {
         private static final String DEFAULT_METHOD_PREFIX = "get";

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPaths.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerPaths.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotation to allow a method / field to have multiple {@link StaplerPath} annotations.
+ */
+@Target({METHOD, FIELD})
+@Retention(RUNTIME)
+@Documented
+public @interface StaplerPaths {
+    StaplerPath[] value();
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerRMI.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerRMI.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Indicates that the method is exposed to client-side JavaScript proxies
+ * and is callable as a method from them.
+ *
+ * <p>
+ * {@link StaplerPath#INFER_FROM_NAME} rules are as follows:
+ * <ul>
+ * <li>Method name starts with {@code js}, the {@code js} prefix is removed and the next letter converted to
+ * lowercase, so {@code jsFoo} will be inferred as {@code foo}</li>
+ * <li>Method name does not start with {@code js}, the method name is taken as is</li>
+ * </ul>
+ * <p>
+ * Neither {@link StaplerPath#INDEX} nor {@link StaplerPath#DYNAMIC} matching are supported and will silently be
+ * ignored if present.
+ *
+ * @since TODO
+ */
+@Target(METHOD)
+@Retention(RUNTIME)
+@Documented
+public @interface StaplerRMI {
+}

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerRMI.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerRMI.java
@@ -49,7 +49,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Target(METHOD)
 @Retention(RUNTIME)
-@StaplerPath.Implicit
+@StaplerPath.Implicit(methodPrefix = "js")
 @Documented
 public @interface StaplerRMI {
 }

--- a/core/src/main/java/org/kohsuke/stapler/annotations/StaplerRMI.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/StaplerRMI.java
@@ -49,6 +49,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  */
 @Target(METHOD)
 @Retention(RUNTIME)
+@StaplerPath.Implicit
 @Documented
 public @interface StaplerRMI {
 }

--- a/core/src/main/java/org/kohsuke/stapler/annotations/package-info.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/package-info.java
@@ -22,5 +22,96 @@
  */
 
 /**
+ * Stapler routing annotations.
+ *
+ * This package contains a consolidated set of annotations used to determine how requests get routed to their handlers
+ * by {@link org.kohsuke.stapler.Stapler}. The annotations can be grouped into four sections:
+ * <ul>
+ * <li>URI path binding annotations:
+ * <ul><li>{@link org.kohsuke.stapler.annotations.StaplerPath}</li>
+ * <li>{@link org.kohsuke.stapler.annotations.StaplerPaths}</li>
+ * </ul>
+ * These annotations are valid on public methods and public fields. If a method is annotated with any of the
+ * {@link org.kohsuke.stapler.annotations} annotations (technically with any annotation marked
+ * with the {@link org.kohsuke.stapler.annotations.StaplerPath.Implicit} meta-annotation) it is assumed to have an
+ * implicit annotation of {@link org.kohsuke.stapler.annotations.StaplerPath} with
+ * {@link org.kohsuke.stapler.annotations.StaplerPath#INFER_FROM_NAME} unless an explicit
+ * {@link org.kohsuke.stapler.annotations.StaplerPath} annotation has been provided.
+ * <p>
+ * For {@link org.kohsuke.stapler.annotations.StaplerObject} annotated types, only public methods and fields with
+ * a {@link org.kohsuke.stapler.annotations.StaplerPath} (or
+ * {@linkplain org.kohsuke.stapler.annotations.StaplerPath.Implicit implicitly} annotated)
+ * will be bound to URIs.
+ * </li>
+ * <li>{@link javax.servlet.http.HttpServletRequest#getMethod()} filtering annotations:
+ * <ul><li>{@link org.kohsuke.stapler.annotations.StaplerMethod}</li>
+ * <li>{@link org.kohsuke.stapler.annotations.StaplerMethods}</li>
+ * <li>{@link org.kohsuke.stapler.annotations.StaplerCONNECT}</li>
+ * <li>{@link org.kohsuke.stapler.annotations.StaplerDELETE}</li>
+ * <li>{@link org.kohsuke.stapler.annotations.StaplerGET}</li>
+ * <li>{@link org.kohsuke.stapler.annotations.StaplerHEAD}</li>
+ * <li>{@link org.kohsuke.stapler.annotations.StaplerPATCH}</li>
+ * <li>{@link org.kohsuke.stapler.annotations.StaplerPOST}</li>
+ * <li>{@link org.kohsuke.stapler.annotations.StaplerPUT}</li>
+ * <li>{@link org.kohsuke.stapler.annotations.StaplerRMI} - this is annotation matches both
+ * {@link javax.servlet.http.HttpServletRequest#getMethod()} and
+ * {@link javax.servlet.http.HttpServletRequest#getContentType()} and is used to expose RMI to client side JavaScript
+ * </li>
+ * </ul>
+ * These annotations are valid on public methods and have the
+ * {@link org.kohsuke.stapler.annotations.StaplerPath.Implicit} meta-annotation which implies a
+ * {@link org.kohsuke.stapler.annotations.StaplerPath}
+ * with {@link org.kohsuke.stapler.annotations.StaplerPath#INFER_FROM_NAME} unless an explicit
+ * {@link org.kohsuke.stapler.annotations.StaplerPath} annotation has been provided.
+ * <p>
+ * In the event of a method with multiple annotations in this category, one must match for the method to be selected.
+ * <p>
+ * In the event of multiple methods with different annotations in this category, only the matching method will be
+ * selected.
+ * <p>
+ * In the event of multiple methods with the same equivalent annotations in this category, the most specific method
+ * (base on other categories of annotations) will be selected. If there is no clear winner then the exact method to be
+ * selected is undefined.
+ * </li>
+ * <li>{@link javax.servlet.http.HttpServletRequest#getContentType()} filtering annotations:
+ * <ul><li>{@link org.kohsuke.stapler.annotations.StaplerContent}</li>
+ * <li>{@link org.kohsuke.stapler.annotations.StaplerContents}</li>
+ * <li>{@link org.kohsuke.stapler.annotations.StaplerRMI} - this is annotation matches both
+ * {@link javax.servlet.http.HttpServletRequest#getMethod()} and
+ * {@link javax.servlet.http.HttpServletRequest#getContentType()} and is used to expose RMI to client side JavaScript
+ * </ul>
+ * These annotations are valid on public methods and have the
+ * {@link org.kohsuke.stapler.annotations.StaplerPath.Implicit} meta-annotation which implies a
+ * {@link org.kohsuke.stapler.annotations.StaplerPath}
+ * with {@link org.kohsuke.stapler.annotations.StaplerPath#INFER_FROM_NAME} unless an explicit
+ * {@link org.kohsuke.stapler.annotations.StaplerPath} annotation has been provided.
+ * <p>
+ * In the event of a method with multiple annotations in this category, one must match for the method to be selected.
+ * <p>
+ * In the event of multiple methods with different annotations in this category, only the matching method will be
+ * selected.
+ * <p>
+ * In the event of multiple methods with the same equivalent annotations in this category, the most specific method
+ * (base on other categories of annotations) will be selected. If there is no clear winner then the exact method to be
+ * selected is undefined.
+ * </li>
+ * <li>Class level annotations:
+ * <ul>
+ * <li>{@link org.kohsuke.stapler.annotations.StaplerFacet} and {@link org.kohsuke.stapler.annotations.StaplerFacets}
+ * document expected {@link org.kohsuke.stapler.Facet}s that should be assoicated with the annotated class.
+ * </li>
+ * <li>{@link org.kohsuke.stapler.annotations.StaplerFragment} and
+ * {@link org.kohsuke.stapler.annotations.StaplerFragments} document expected
+ * {@link org.kohsuke.stapler.AbstractTearOff}s that should be assoicated with the annotated class.
+ * </li>
+ * <li>{@link org.kohsuke.stapler.annotations.StaplerObject} identifies classes that are completely annotated with
+ * {@link org.kohsuke.stapler.annotations}-based annotations and therefore more complete consistency checks can
+ * be enforced at compile time.
+ * <p>
+ * TODO: determine how to handle inheritance
+ * </li>
+ * </ul></li>
+ * </ul>
+ * @since TODO
  */
 package org.kohsuke.stapler.annotations;

--- a/core/src/main/java/org/kohsuke/stapler/annotations/package-info.java
+++ b/core/src/main/java/org/kohsuke/stapler/annotations/package-info.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (c) 2017, Stephen Connolly, CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ */
+package org.kohsuke.stapler.annotations;

--- a/core/src/main/java/org/kohsuke/stapler/lang/AnnotatedRef.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/AnnotatedRef.java
@@ -6,10 +6,16 @@ import java.lang.annotation.Annotation;
  * @author Kohsuke Kawaguchi
  */
 public abstract class AnnotatedRef {
+    private static final Annotation[] EMPTY_ANNOTATIONS = new Annotation[0];
+
     // no subtyping outside the package
     /*package*/ AnnotatedRef() {}
 
     public abstract <T extends Annotation> T getAnnotation(Class<T> type);
+
+    public Annotation[] getAnnotations() {
+        return EMPTY_ANNOTATIONS;
+    }
 
     public boolean hasAnnotation(Class<? extends Annotation> type) {
         return getAnnotation(type)!=null;

--- a/core/src/main/java/org/kohsuke/stapler/lang/FieldRef.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/FieldRef.java
@@ -68,6 +68,13 @@ public abstract class FieldRef extends AnnotatedRef {
             public boolean isRoutable() {
                 return Modifier.isPublic(f.getModifiers());
             }
+
+            @Override
+            public Class<?> getDeclaringClass() {
+                return f.getDeclaringClass();
+            }
         };
     }
+
+    public abstract Class<?> getDeclaringClass();
 }

--- a/core/src/main/java/org/kohsuke/stapler/lang/FieldRef.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/FieldRef.java
@@ -45,6 +45,11 @@ public abstract class FieldRef extends AnnotatedRef {
             }
 
             @Override
+            public Annotation[] getAnnotations() {
+                return f.getAnnotations();
+            }
+
+            @Override
             public String getName() {
                 return f.getName();
             }

--- a/core/src/main/java/org/kohsuke/stapler/lang/Klass.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/Klass.java
@@ -4,7 +4,6 @@ import org.kohsuke.stapler.Function;
 
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;

--- a/core/src/main/java/org/kohsuke/stapler/lang/KlassNavigator.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/KlassNavigator.java
@@ -1,5 +1,6 @@
 package org.kohsuke.stapler.lang;
 
+import java.lang.reflect.Modifier;
 import org.kohsuke.stapler.ClassDescriptor;
 import org.kohsuke.stapler.Function;
 import org.kohsuke.stapler.MetaClassLoader;
@@ -14,6 +15,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import org.kohsuke.stapler.annotations.StaplerObject;
+import org.kohsuke.stapler.annotations.StaplerPath;
 
 /**
  * Strategy pattern to provide navigation across class-like objects in other languages of JVM.

--- a/core/src/main/java/org/kohsuke/stapler/lang/MethodRef.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/MethodRef.java
@@ -42,6 +42,11 @@ public abstract class MethodRef extends AnnotatedRef {
             }
 
             @Override
+            public Annotation[] getAnnotations() {
+                return m.getAnnotations();
+            }
+
+            @Override
             public boolean isRoutable() {
                 if (m.isBridge())    return false;
                 return (m.getModifiers() & Modifier.PUBLIC)!=0;

--- a/core/src/main/java/org/kohsuke/stapler/lang/util/FieldRefFilter.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/util/FieldRefFilter.java
@@ -51,4 +51,9 @@ public abstract class FieldRefFilter extends FieldRef {
     public boolean hasAnnotation(Class<? extends Annotation> type) {
         return getBase().hasAnnotation(type);
     }
+
+    @Override
+    public Class<?> getDeclaringClass() {
+        return getBase().getDeclaringClass();
+    }
 }

--- a/core/src/main/java/org/kohsuke/stapler/lang/util/FieldRefFilter.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/util/FieldRefFilter.java
@@ -43,6 +43,11 @@ public abstract class FieldRefFilter extends FieldRef {
     }
 
     @Override
+    public Annotation[] getAnnotations() {
+        return getBase().getAnnotations();
+    }
+
+    @Override
     public boolean hasAnnotation(Class<? extends Annotation> type) {
         return getBase().hasAnnotation(type);
     }

--- a/core/src/main/java/org/kohsuke/stapler/lang/util/MethodRefFilter.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/util/MethodRefFilter.java
@@ -39,6 +39,11 @@ public abstract class MethodRefFilter extends MethodRef {
     }
 
     @Override
+    public Annotation[] getAnnotations() {
+        return getBase().getAnnotations();
+    }
+
+    @Override
     public boolean hasAnnotation(Class<? extends Annotation> type) {
         return getBase().hasAnnotation(type);
     }

--- a/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
+import org.kohsuke.stapler.annotations.StaplerBinder;
 
 /**
  * @author Kohsuke Kawaguchi
@@ -98,6 +99,40 @@ public class DataBindingTest extends TestCase {
         @CapturedParameterNames({"req","b"})
         public static Binder fromStapler(StaplerRequest req, @QueryParameter String b) {
             Binder r = new Binder();
+            r.req = req;
+            r.b = b;
+            return r;
+        }
+    }
+
+    public void testStaplerBinderMethod() throws Exception {
+        MockRequest mr = new MockRequest() {
+            @Override
+            public String getContentType() {
+                return "text/html";
+            }
+        };
+        mr.getParameterMap().put("a","123");
+        mr.getParameterMap().put("b","string");
+        RequestImpl req = new RequestImpl(new Stapler(), mr, Collections.<AncestorImpl>emptyList(), null);
+        new Function.InstanceFunction(getClass().getMethod("doStaplerBinderMethod",StaplerRequest.class,int.class,Binder2.class))
+                .bindAndInvoke(this,req,null);
+    }
+
+    public void doStaplerBinderMethod(StaplerRequest req, @QueryParameter int a, Binder2 b) {
+        assertEquals(123,a);
+        assertSame(req,b.req);
+        assertEquals("string",b.b);
+
+    }
+
+    public static class Binder2 {
+        StaplerRequest req;
+        String b;
+
+        @StaplerBinder
+        public static Binder2 factory(StaplerRequest req, @QueryParameter String b) {
+            Binder2 r = new Binder2();
             r.req = req;
             r.b = b;
             return r;

--- a/core/src/test/java/org/kohsuke/stapler/DispatcherTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DispatcherTest.java
@@ -6,6 +6,7 @@ import com.gargoylesoftware.htmlunit.TextPage;
 import com.gargoylesoftware.htmlunit.WebClient;
 import com.gargoylesoftware.htmlunit.WebRequestSettings;
 import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -13,6 +14,7 @@ import java.lang.reflect.Field;
 import java.net.HttpURLConnection;
 import java.net.ProtocolException;
 import java.net.URL;
+import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
 import java.security.AccessController;
 import java.security.PrivilegedActionException;
@@ -50,7 +52,7 @@ public class DispatcherTest extends JettyTestCase {
     public final IndexDispatchByName indexDispatchByName = new IndexDispatchByName();
 
     public class IndexDispatchByName {
-        @WebMethod(name="")
+        @WebMethod(name = "")
         public HttpResponse doHelloWorld() {
             return HttpResponses.text("Hello world");
         }
@@ -72,12 +74,14 @@ public class DispatcherTest extends JettyTestCase {
     public final VerbMatch verbMatch = new VerbMatch();
 
     public class VerbMatch {
-        @WebMethod(name="") @GET
+        @WebMethod(name = "")
+        @GET
         public HttpResponse doGet() {
             return HttpResponses.text("Got GET");
         }
 
-        @WebMethod(name="") @POST
+        @WebMethod(name = "")
+        @POST
         public HttpResponse doPost() {
             return HttpResponses.text("Got POST");
         }
@@ -112,21 +116,21 @@ public class DispatcherTest extends JettyTestCase {
     @StaplerObject
     public class ContentMatch {
 
-        @StaplerPaths({@StaplerPath(StaplerPath.INDEX),@StaplerPath("text")})
+        @StaplerPaths({@StaplerPath(StaplerPath.INDEX), @StaplerPath("text")})
         @StaplerPOST
         @StaplerContent(StaplerContent.ANY_TEXT)
         public HttpResponse doText() {
             return HttpResponses.text("I got text");
         }
 
-        @StaplerPaths({@StaplerPath(StaplerPath.INDEX),@StaplerPath("xml")})
+        @StaplerPaths({@StaplerPath(StaplerPath.INDEX), @StaplerPath("xml")})
         @StaplerPOST
         @StaplerContent("*/xml")
         public HttpResponse doXml() {
             return HttpResponses.text("I got xml");
         }
 
-        @StaplerPaths({@StaplerPath(StaplerPath.INDEX),@StaplerPath("json")})
+        @StaplerPaths({@StaplerPath(StaplerPath.INDEX), @StaplerPath("json")})
         @StaplerPOST
         @StaplerContent("application/json")
         public HttpResponse doJson() {
@@ -171,7 +175,8 @@ public class DispatcherTest extends JettyTestCase {
             try (InputStream is = connection.getInputStream()) {
                 IOUtils.copy(is, in);
             }
-            assertEquals("Content-Type " + contentType + " on path " + path, expectedResponse, new String(in.toByteArray(), StandardCharsets.UTF_8));
+            assertEquals("Content-Type " + contentType + " on path " + path, expectedResponse,
+                    new String(in.toByteArray(), StandardCharsets.UTF_8));
         } finally {
             connection.disconnect();
         }
@@ -209,25 +214,25 @@ public class DispatcherTest extends JettyTestCase {
             };
         }
 
-        @StaplerPaths({@StaplerPath(StaplerPath.INDEX),@StaplerPath("connect")})
+        @StaplerPaths({@StaplerPath(StaplerPath.INDEX), @StaplerPath("connect")})
         @StaplerCONNECT
         public HttpResponse doConnect() {
             return response("connect");
         }
 
-        @StaplerPaths({@StaplerPath(StaplerPath.INDEX),@StaplerPath("delete")})
+        @StaplerPaths({@StaplerPath(StaplerPath.INDEX), @StaplerPath("delete")})
         @StaplerDELETE
         public HttpResponse doDelete() {
             return response("delete");
         }
 
-        @StaplerPaths({@StaplerPath(StaplerPath.INDEX),@StaplerPath("get")})
+        @StaplerPaths({@StaplerPath(StaplerPath.INDEX), @StaplerPath("get")})
         @StaplerGET
         public HttpResponse doGet() {
             return response("get");
         }
 
-        @StaplerPaths({@StaplerPath(StaplerPath.INDEX),@StaplerPath("head")})
+        @StaplerPaths({@StaplerPath(StaplerPath.INDEX), @StaplerPath("head")})
         @StaplerHEAD
         public HttpResponse doHead() {
             return response("head");
@@ -257,9 +262,11 @@ public class DispatcherTest extends JettyTestCase {
             return response("custom");
         }
 
-        @StaplerMethods({@StaplerMethod("CONNECT"), @StaplerMethod("DELETE"), @StaplerMethod("GET"),
-                         @StaplerMethod("HEAD"), @StaplerMethod("PATCH"), @StaplerMethod("POST"),
-                         @StaplerMethod("PUT"), @StaplerMethod("CUSTOM")})
+        @StaplerMethods({
+                                @StaplerMethod("CONNECT"), @StaplerMethod("DELETE"), @StaplerMethod("GET"),
+                                @StaplerMethod("HEAD"), @StaplerMethod("PATCH"), @StaplerMethod("POST"),
+                                @StaplerMethod("PUT"), @StaplerMethod("CUSTOM")
+                        })
         public HttpResponse doAll() {
             return response(Stapler.getCurrentRequest().getMethod().toLowerCase(Locale.ENGLISH));
         }
@@ -270,11 +277,11 @@ public class DispatcherTest extends JettyTestCase {
      */
     public void testMethodMatch() throws Exception {
         String[] methods = {"CONNECT", "DELETE", "GET", "HEAD", "PATCH", "POST", "PUT", "CUSTOM"};
-        for (String method1: methods) {
+        for (String method1 : methods) {
             check(method1, "all", 200);
             // check(method1, "", 200); // FIXME uncomment once StaplerPath support added
-            for (String method2: methods) {
-                check(method1, method2.toLowerCase(), method1.equals(method2)?200:404);
+            for (String method2 : methods) {
+                check(method1, method2.toLowerCase(), method1.equals(method2) ? 200 : 404);
             }
         }
     }
@@ -343,7 +350,7 @@ public class DispatcherTest extends JettyTestCase {
     public final ArbitraryWebMethodName arbitraryWebMethodName = new ArbitraryWebMethodName();
 
     public class ArbitraryWebMethodName {
-        @WebMethod(name="")
+        @WebMethod(name = "")
         public HttpResponse notDoPrefix() {
             return HttpResponses.text("I'm index");
         }
@@ -379,7 +386,7 @@ public class DispatcherTest extends JettyTestCase {
     }
 
     public static class Point {
-        public int x,y;
+        public int x, y;
     }
 
     /**
@@ -395,10 +402,10 @@ public class DispatcherTest extends JettyTestCase {
         }
 
         WebRequestSettings req = new WebRequestSettings(new URL(url, "interceptorStage/foo"), HttpMethod.POST);
-        req.setAdditionalHeader("Content-Type","application/json");
+        req.setAdditionalHeader("Content-Type", "application/json");
         req.setRequestBody("{x:3,y:5}");
         TextPage p = wc.getPage(req);
-        assertEquals("3,5",p.getContent());
+        assertEquals("3,5", p.getContent());
 
     }
 
@@ -412,10 +419,10 @@ public class DispatcherTest extends JettyTestCase {
         }
 
         WebRequestSettings req = new WebRequestSettings(new URL(url, "interceptorStage/foo"), HttpMethod.POST);
-        req.setAdditionalHeader("Content-Type","application/json; charset=utf-8");
+        req.setAdditionalHeader("Content-Type", "application/json; charset=utf-8");
         req.setRequestBody("{x:3,y:5}");
         TextPage p = wc.getPage(req);
-        assertEquals("3,5",p.getContent());
+        assertEquals("3,5", p.getContent());
 
     }
 
@@ -423,8 +430,9 @@ public class DispatcherTest extends JettyTestCase {
 
 
     public final Inheritance inheritance = new Inheritance2();
+
     public class Inheritance {
-        @WebMethod(name="foo")
+        @WebMethod(name = "foo")
         public HttpResponse doBar(@QueryParameter String q) {
             return HttpResponses.text("base");
         }
@@ -449,13 +457,15 @@ public class DispatcherTest extends JettyTestCase {
             wc.getPage(new URL(url, "inheritance/bar"));
             fail();
         } catch (FailingHttpStatusCodeException e) {
-            assertEquals(404,e.getStatusCode());
+            assertEquals(404, e.getStatusCode());
         }
     }
 
     public final PutInheritance putInheritance = new PutInheritanceImpl();
+
     public abstract class PutInheritance {
-        @WebMethod(name="foo") @PUT
+        @WebMethod(name = "foo")
+        @PUT
         public abstract HttpResponse doBar(StaplerRequest req) throws IOException;
 
         @POST
@@ -464,7 +474,7 @@ public class DispatcherTest extends JettyTestCase {
         }
     }
 
-    public class PutInheritanceImpl extends PutInheritance{
+    public class PutInheritanceImpl extends PutInheritance {
         @Override
         public HttpResponse doBar(StaplerRequest req) throws IOException {
             return HttpResponses.text(IOUtils.toString(req.getInputStream()) + " World!");
@@ -485,7 +495,7 @@ public class DispatcherTest extends JettyTestCase {
             wc.getPage(new URL(url, "putInheritance/bar"));
             fail();
         } catch (FailingHttpStatusCodeException e) {
-            assertEquals(404,e.getStatusCode());
+            assertEquals(404, e.getStatusCode());
         }
 
         //Invoke Post as well
@@ -495,14 +505,367 @@ public class DispatcherTest extends JettyTestCase {
         assertEquals("POST: Hello", p.getContent());
     }
 
+    public class AnnotationInheritance {
+        public final HttpResponse doMagicFinal(@QueryParameter String q) {
+            return HttpResponses.text("root: " + q);
+        }
 
+        @StaplerGET
+        @StaplerPath("annotated-final")
+        public final HttpResponse doAnnotatedFinal(@QueryParameter String q) {
+            return HttpResponses.text("root: " + q);
+        }
+
+        public HttpResponse doMagicBase(@QueryParameter String q) {
+            return HttpResponses.text("root: " + q);
+        }
+
+        @StaplerGET
+        @StaplerPath("annotated-base")
+        public HttpResponse doAnnotatedBase(@QueryParameter String q) {
+            return HttpResponses.text("root: " + q);
+        }
+
+        public HttpResponse doMagicBaseOverrideAnnotated(@QueryParameter String q) {
+            return HttpResponses.text("root: " + q);
+        }
+
+        @StaplerGET
+        @StaplerPath("annotated-base-override-annotated")
+        public HttpResponse doAnnotatedBaseOverrideAnnotated(@QueryParameter String q) {
+            return HttpResponses.text("root: " + q);
+        }
+
+        public HttpResponse doMagicBaseOverrideNoAnnotation(@QueryParameter String q) {
+            return HttpResponses.text("root: " + q);
+        }
+
+        @StaplerGET
+        @StaplerPath("annotated-base-override-no-annotation")
+        public HttpResponse doAnnotatedBaseOverrideNoAnnotation(@QueryParameter String q) {
+            return HttpResponses.text("root: " + q);
+        }
+    }
+
+    @StaplerObject
+    public class AnnotationInheritance2 extends AnnotationInheritance {
+
+        @StaplerGET
+        public HttpResponse doMagicBaseOverrideAnnotated(@QueryParameter String q) {
+            return HttpResponses.text("child: " + q);
+        }
+
+        @StaplerGET
+        @StaplerPath("annotated-base-override-annotated")
+        public HttpResponse doAnnotatedBaseOverrideAnnotated(@QueryParameter String q) {
+            return HttpResponses.text("child: " + q);
+        }
+
+        public HttpResponse doMagicBaseOverrideNoAnnotation(String q) {
+            return HttpResponses.text("child: " + q);
+        }
+
+        public HttpResponse doAnnotatedBaseOverrideNoAnnotation(String q) {
+            return HttpResponses.text("child: " + q);
+        }
+
+
+        public final HttpResponse doMagicFinal2(@QueryParameter String q) {
+            return HttpResponses.text("child: " + q);
+        }
+
+        @StaplerGET
+        @StaplerPath("annotated-final2")
+        public final HttpResponse doAnnotatedFinal2(@QueryParameter String q) {
+            return HttpResponses.text("child: " + q);
+        }
+
+        public HttpResponse doMagicBase2(@QueryParameter String q) {
+            return HttpResponses.text("child: " + q);
+        }
+
+        @StaplerGET
+        @StaplerPath("annotated-base2")
+        public HttpResponse doAnnotatedBase2(@QueryParameter String q) {
+            return HttpResponses.text("child: " + q);
+        }
+
+        public HttpResponse doMagicBaseOverrideAnnotated2(@QueryParameter String q) {
+            return HttpResponses.text("child: " + q);
+        }
+
+        @StaplerGET
+        @StaplerPath("annotated-base-override-annotated2")
+        public HttpResponse doAnnotatedBaseOverrideAnnotated2(@QueryParameter String q) {
+            return HttpResponses.text("child: " + q);
+        }
+
+        public HttpResponse doMagicBaseOverrideNoAnnotation2(@QueryParameter String q) {
+            return HttpResponses.text("child: " + q);
+        }
+
+        @StaplerGET
+        @StaplerPath("annotated-base-override-no-annotation2")
+        public HttpResponse doAnnotatedBaseOverrideNoAnnotation2(@QueryParameter String q) {
+            return HttpResponses.text("child: " + q);
+        }
+    }
+
+    public class AnnotationInheritance3 extends AnnotationInheritance2 {
+
+        @StaplerGET
+        public HttpResponse doMagicBaseOverrideAnnotated(@QueryParameter String q) {
+            return HttpResponses.text("leaf: " + q);
+        }
+
+        @StaplerGET
+        public HttpResponse doAnnotatedBaseOverrideAnnotated(@QueryParameter String q) {
+            return HttpResponses.text("leaf: " + q);
+        }
+
+        public HttpResponse doMagicBaseOverrideNoAnnotation(String q) {
+            return HttpResponses.text("leaf: " + q);
+        }
+
+        public HttpResponse doAnnotatedBaseOverrideNoAnnotation(String q) {
+            return HttpResponses.text("leaf: " + q);
+        }
+
+        @StaplerGET
+        public HttpResponse doMagicBaseOverrideAnnotated2(@QueryParameter String q) {
+            return HttpResponses.text("leaf: " + q);
+        }
+
+        @StaplerGET
+        public HttpResponse doAnnotatedBaseOverrideAnnotated2(@QueryParameter String q) {
+            return HttpResponses.text("leaf: " + q);
+        }
+
+        public HttpResponse doMagicBaseOverrideNoAnnotation2(String q) {
+            return HttpResponses.text("leaf: " + q);
+        }
+
+        public HttpResponse doAnnotatedBaseOverrideNoAnnotation2(String q) {
+            return HttpResponses.text("leaf: " + q);
+        }
+    }
+
+    public final AnnotationInheritance annotationInheritanceA = new AnnotationInheritance2();
+    public final AnnotationInheritance annotationInheritanceB = new AnnotationInheritance3();
+
+    public void testGiven__staplerObject_extends_magic__when__finalMethodInBaseClass__then__magicUsed()
+            throws Exception {
+        assertFound("annotationInheritanceA/magicFinal?q=123", "root: 123");
+    }
+
+    public void testGiven__staplerObject_extends_magic__when__annotatedFinalMethodInBaseClass__then__annotationUsed()
+            throws Exception {
+        assertFound("annotationInheritanceA/annotated-final?q=123", "root: 123");
+    }
+
+    public void testGiven__staplerObject_extends_magic__when__methodImplInBaseClass__then__magicUsed()
+            throws Exception {
+        assertFound("annotationInheritanceA/magicBase?q=123", "root: 123");
+    }
+
+    public void testGiven__staplerObject_extends_magic__when__annotatedMethodImplInBaseClass__then__annotationUsed()
+            throws Exception {
+        assertFound("annotationInheritanceA/annotated-base?q=123", "root: 123");
+    }
+
+    public void testGiven__staplerObject_extends_magic__when__magicInAnnotatedClass__then__404()
+            throws Exception {
+        assertNotFound("annotationInheritanceA/magicBaseOverrideAnnotated2?q=123");
+    }
+
+    public void testGiven__staplerObject_extends_magic__when__annotationsInAnnotatedClass__then__annotationUsed()
+            throws Exception {
+        assertFound("annotationInheritanceA/annotated-base-override-annotated2?q=123", "child: 123");
+    }
+
+    public void testGiven__staplerObject_extends_magic__when__magicInAnnotatedClass2__then__404()
+            throws Exception {
+        assertNotFound("annotationInheritanceA/magicBaseOverrideNoAnnotation2?q=123");
+    }
+
+    public void testGiven__staplerObject_extends_magic__when__annotationsInAnnotatedClass2__then__annotationUsed()
+            throws Exception {
+        assertFound("annotationInheritanceA/annotated-base-override-no-annotation2?q=123", "child: 123");
+    }
+
+    public void testGiven__staplerObject_extends_magic__when__magicFinalMethodInAnnotatedClass__then__404()
+            throws Exception {
+        assertNotFound("annotationInheritanceA/magicFinal2?q=123");
+    }
+
+    public void testGiven__staplerObject_extends_magic__when__annotatedFinalMethodInAnnotatedClass__then__annotationUsed()
+            throws Exception {
+        assertFound("annotationInheritanceA/annotated-final2?q=123", "child: 123");
+    }
+
+    public void testGiven__staplerObject_extends_magic__when__methodImplInAnnotatedClass__then_404()
+            throws Exception {
+        assertNotFound("annotationInheritanceA/magicBase2?q=123");
+    }
+
+    public void testGiven__staplerObject_extends_magic__when__annotatedMethodImplInAnnotatedClass__then__annotationUsed()
+            throws Exception {
+        assertFound("annotationInheritanceA/annotated-base2?q=123", "child: 123");
+    }
+
+    public void testGiven__staplerObject_extends_magic__when__overrideMagicWithAnnotations__then__annotationUsed()
+            throws Exception {
+        assertFound("annotationInheritanceA/magicBaseOverrideAnnotated?q=123", "child: 123");
+    }
+
+    public void testGiven__staplerObject_extends_magic__when__overrideAnnotationsWithAnnotations__then__annotationUsed()
+            throws Exception {
+        assertFound("annotationInheritanceA/annotated-base-override-annotated?q=123", "child: 123");
+    }
+
+    public void testGiven__staplerObject_extends_magic__when__overrideMagicWithoutAnnotations__then__404()
+            throws Exception {
+        assertNotFound("annotationInheritanceA/magicBaseOverrideNoAnnotation?q=123");
+    }
+
+    public void testGiven__staplerObject_extends_magic__when__overrideAnnotationsWithoutAnnotations__then__404()
+            throws Exception {
+        assertNotFound("annotationInheritanceA/annotated-base-override-no-annotation?q=123");
+    }
+
+    public void testGiven__magic_extends_staplerObject_extends_magic__when__finalMethodInBaseClass__then__magicUsed()
+            throws Exception {
+        assertFound("annotationInheritanceB/magicFinal?q=123", "root: 123");
+    }
+
+    public void testGiven__magic_extends_staplerObject_extends_magic__when__annotatedFinalMethodInBaseClass__then__annotationUsed()
+            throws Exception {
+        assertFound("annotationInheritanceB/annotated-final?q=123", "root: 123");
+    }
+
+    public void testGiven__magic_extends_staplerObject_extends_magic__when__methodImplInBaseClass__then__magicUsed()
+            throws Exception {
+        assertFound("annotationInheritanceB/magicBase?q=123", "root: 123");
+    }
+
+    public void testGiven__magic_extends_staplerObject_extends_magic__when__annotatedMethodImplInBaseClass__then__annotationUsed()
+            throws Exception {
+        assertFound("annotationInheritanceB/annotated-base?q=123", "root: 123");
+    }
+
+    public void testGiven__magic_extends_staplerObject_extends_magic__when__overrideMagicWithAnnotations__then__annotationUsed()
+            throws Exception {
+        assertFound("annotationInheritanceB/magicBaseOverrideAnnotated?q=123", "leaf: 123");
+    }
+
+    public void testGiven__magic_extends_staplerObject_extends_magic__when__overrideAnnotationsWithAnnotations__then__annotationUsed()
+            throws Exception {
+        assertFound("annotationInheritanceB/annotated-base-override-annotated?q=123", "leaf: 123");
+    }
+
+    public void testGiven__magic_extends_staplerObject_extends_magic__when__overrideMagicWithoutAnnotations__then__404()
+            throws Exception {
+        assertNotFound("annotationInheritanceB/magicBaseOverrideNoAnnotation?q=123");
+    }
+
+    public void testGiven__magic_extends_staplerObject_extends_magic__when__overrideAnnotationsWithoutAnnotations2__then__annotationUsed()
+            throws Exception {
+        assertFound("annotationInheritanceB/annotated-base-override-no-annotation?q=123", "leaf: 123");
+    }
+
+    public void testGiven__magic_extends_staplerObject_extends_magic__when__magicFinalMethodInAnnotatedClass__then__404()
+            throws Exception {
+        assertNotFound("annotationInheritanceB/magicFinal2?q=123");
+    }
+
+    public void testGiven__magic_extends_staplerObject_extends_magic__when__annotatedFinalMethodInAnnotatedClass__then__annotationUsed()
+            throws Exception {
+        assertFound("annotationInheritanceB/annotated-final2?q=123", "child: 123");
+    }
+
+    public void testGiven__magic_extends_staplerObject_extends_magic__when__magicMethodImplInAnnotatedClass__then__404()
+            throws Exception {
+        assertNotFound("annotationInheritanceB/magicBase2?q=123");
+    }
+
+    public void testGiven__magic_extends_staplerObject_extends_magic__when__annotatedMethodImplInAnnotatedClass__then__annotationUsed()
+            throws Exception {
+        assertFound("annotationInheritanceB/annotated-base2?q=123", "child: 123");
+    }
+
+    public void testGiven__magic_extends_staplerObject_extends_magic__when__overrideWithAnnotations1__then__annotationUsed()
+            throws Exception {
+        assertFound("annotationInheritanceB/magicBaseOverrideAnnotated2?q=123", "leaf: 123");
+    }
+
+    public void testGiven__magic_extends_staplerObject_extends_magic__when__overrideWithAnnotations2__then__annotationUsed()
+            throws Exception {
+        assertFound("annotationInheritanceB/annotated-base-override-annotated2?q=123", "leaf: 123");
+    }
+
+    public void testGiven__magic_extends_staplerObject_extends_magic__when__overrideMagicWithoutAnnotations__then__magicUsed()
+            throws Exception {
+        assertFound("annotationInheritanceB/magicBaseOverrideNoAnnotation2?q=123", "leaf: 123");
+    }
+
+    public void testGiven__magic_extends_staplerObject_extends_magic__when__overrideAnnotationsWithoutAnnotations__then__annotationUsed()
+            throws Exception {
+        assertFound("annotationInheritanceB/annotated-base-override-no-annotation2?q=123", "leaf: 123");
+    }
+
+    private void assertFound(String relativeUrl, String expectedContent) throws IOException {
+        try {
+            HttpURLConnection connection = (HttpURLConnection) new URL(url, relativeUrl).openConnection();
+            int status = connection.getResponseCode();
+            if (status/100 == 2) {
+                String result;
+                try (InputStream is = connection.getInputStream()) {
+                    result = IOUtils.toString(is);
+                } finally {
+                    connection.disconnect();
+                }
+                assertEquals(expectedContent, result);
+            } else {
+                String result = "";
+                try (InputStream is = connection.getInputStream()) {
+                    result = IOUtils.toString(is);
+                } catch (FileNotFoundException e) {
+                    // ignore
+                }
+                fail("Expected HTTP/20x at " + relativeUrl + ", got HTTP/" + status + "\n" + result);
+            }
+        } catch (FileNotFoundException e) {
+            fail("Expected HTTP/20x at " + relativeUrl);
+        }
+    }
+
+    private void assertNotFound(String relativeUrl) throws IOException {
+        HttpURLConnection connection = (HttpURLConnection) new URL(url, relativeUrl).openConnection();
+        try {
+            int status = connection.getResponseCode();
+            if (status == 404) {
+                return;
+            }
+            String result = "";
+            try (InputStream is = connection.getInputStream()) {
+                result = IOUtils.toString(is);
+            } catch (FileNotFoundException e) {
+                // ignore
+            }
+            fail("Expected HTTP/404 at " + relativeUrl + ", got HTTP/" + status + "\n"+result);
+        } finally {
+            connection.disconnect();
+        }
+    }
 
     //===================================================================
 
 
     public final RequirePostOnBase requirePostOnBase = new RequirePostOnBase2();
+
     public abstract class RequirePostOnBase {
         int hit;
+
         @RequirePOST
         public abstract void doSomething();
     }
@@ -534,21 +897,27 @@ public class DispatcherTest extends JettyTestCase {
         TextPage p = new WebClient().getPage(new URL(url, "overloaded/x"));
         assertEquals("doX(StaplerRequest)", p.getContent());
     }
+
     public final Object overloaded = new Overloaded();
+
     public static class Overloaded {
         @Deprecated
         public HttpResponse doX() {
             return HttpResponses.text("doX()");
         }
+
         public HttpResponse doX(StaplerRequest req) {
             return HttpResponses.text("doX(StaplerRequest)");
         }
+
         public HttpResponse doX(StaplerResponse rsp) {
             return HttpResponses.text("doX(StaplerResponse)");
         }
+
         public HttpResponse doX(StaplerRequest req, StaplerResponse rsp) {
             return HttpResponses.text("doX(StaplerRequest, StaplerResponse)");
         }
+
         @WebMethod(name = "x")
         public HttpResponse x() {
             return HttpResponses.text("x()");
@@ -557,18 +926,18 @@ public class DispatcherTest extends JettyTestCase {
 
     public final TestWithPublicField testWithPublicField = new TestWithPublicField();
 
-    public  class TestWithPublicField extends TestWithPublicFieldBase{
+    public class TestWithPublicField extends TestWithPublicFieldBase {
 
     }
 
-    public  class TestWithPublicFieldBase{
-        public TestClass testClass=new TestClass();
+    public class TestWithPublicFieldBase {
+        public TestClass testClass = new TestClass();
     }
 
 
-    public  class TestClass{
-//        @GET @WebMethod(name="")
-        public String doValue(){
+    public class TestClass {
+        //        @GET @WebMethod(name="")
+        public String doValue() {
             return "hello";
         }
     }
@@ -583,8 +952,6 @@ public class DispatcherTest extends JettyTestCase {
             assertEquals(HttpServletResponse.SC_OK, e.getStatusCode());
         }
     }
-
-
 
 
 }

--- a/core/src/test/java/org/kohsuke/stapler/DispatcherTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DispatcherTest.java
@@ -29,6 +29,7 @@ import org.kohsuke.stapler.annotations.StaplerGET;
 import org.kohsuke.stapler.annotations.StaplerHEAD;
 import org.kohsuke.stapler.annotations.StaplerMethod;
 import org.kohsuke.stapler.annotations.StaplerMethods;
+import org.kohsuke.stapler.annotations.StaplerObject;
 import org.kohsuke.stapler.annotations.StaplerPATCH;
 import org.kohsuke.stapler.annotations.StaplerPOST;
 import org.kohsuke.stapler.annotations.StaplerPUT;
@@ -108,6 +109,7 @@ public class DispatcherTest extends JettyTestCase {
 
     public final ContentMatch contentMatch = new ContentMatch();
 
+    @StaplerObject
     public class ContentMatch {
 
         @StaplerPaths({@StaplerPath(StaplerPath.INDEX),@StaplerPath("text")})
@@ -146,11 +148,11 @@ public class DispatcherTest extends JettyTestCase {
         postFail("text/html", "json");
 
         // FIXME uncomment once StaplerPath support added
-        // post("text/plain", "", "I got text");
-        // post("text/html", "", "I got text");
-        // post("application/xml", "", "I got xml");
-        // // post("text/xml", "", "I got xml"); // FIXME uncomment once matching conflict resolution added
-        // post("application/json", "", "I got json");
+        post("text/plain", "", "I got text");
+        post("text/html", "", "I got text");
+        post("application/xml", "", "I got xml");
+        // post("text/xml", "", "I got xml"); // FIXME uncomment once matching conflict resolution added
+        post("application/json", "", "I got json");
 
     }
 

--- a/core/src/test/java/org/kohsuke/stapler/DispatcherTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DispatcherTest.java
@@ -765,7 +765,7 @@ public class DispatcherTest extends JettyTestCase {
 
     public void testGiven__magic_extends_staplerObject_extends_magic__when__overrideMagicWithoutAnnotations__then__404()
             throws Exception {
-        assertNotFound("annotationInheritanceB/magicBaseOverrideNoAnnotation?q=123");
+        assertFound("annotationInheritanceB/magicBaseOverrideNoAnnotation?q=123", "leaf: 123");
     }
 
     public void testGiven__magic_extends_staplerObject_extends_magic__when__overrideAnnotationsWithoutAnnotations2__then__annotationUsed()

--- a/core/src/test/java/org/kohsuke/stapler/annotations/StaplerMethodHelperTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/annotations/StaplerMethodHelperTest.java
@@ -1,0 +1,294 @@
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+import org.kohsuke.stapler.interceptor.InterceptorAnnotation;
+
+import static org.hamcrest.CoreMatchers.anyOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeThat;
+
+@RunWith(Theories.class)
+public class StaplerMethodHelperTest {
+
+    @DataPoints
+    public static Method[] someMethods() {
+        return Probe.class.getDeclaredMethods();
+    }
+
+    private static Method method(String name) throws NoSuchFieldException {
+        for (Method m : Probe.class.getDeclaredMethods()) {
+            if (name.equals(m.getName())) {
+                return m;
+            }
+        }
+        fail("Cannot find a method called '" + name + "' on " + StaplerPathHelperTest.Probe.class);
+        return null;
+    }
+
+    @Theory
+    public void given__privateMethod__when__checking__then__notStaplerMethod(Method method) {
+        assumeThat(Modifier.isPrivate(method.getModifiers()), is(true));
+        assertThat(StaplerMethod.Helper.isMethod(method), is(false));
+    }
+
+    @Theory
+    public void given__packageMethod__when__checking__then__notStaplerMethod(Method method) {
+        assumeThat(Modifier.isPrivate(method.getModifiers()), is(false));
+        assumeThat(Modifier.isProtected(method.getModifiers()), is(false));
+        assumeThat(Modifier.isPublic(method.getModifiers()), is(false));
+        assertThat(StaplerMethod.Helper.isMethod(method), is(false));
+    }
+
+    @Theory
+    public void given__protectedMethod__when__checking__then__notStaplerMethod(Method method) {
+        assumeThat(Modifier.isProtected(method.getModifiers()), is(true));
+        assertThat(StaplerMethod.Helper.isMethod(method), is(false));
+    }
+
+    @Theory
+    public void given__publicMethodWithoutAnnotation__when__checking__then__notStaplerMethod(Method method) {
+        assumeThat(Modifier.isPublic(method.getModifiers()), is(true));
+        assumeThat(method.getDeclaredAnnotations().length, is(0));
+        assertThat(StaplerMethod.Helper.isMethod(method), is(false));
+    }
+
+    @Theory
+    public void given__publicMethodWithoutStaplerMethod__when__checking__then__notStaplerMethod(Method method) {
+        assumeThat(Modifier.isPublic(method.getModifiers()), is(true));
+        for (Annotation a: method.getDeclaredAnnotations()) {
+            InterceptorAnnotation interceptor = a.annotationType().getAnnotation(InterceptorAnnotation.class);
+            assumeThat(interceptor, nullValue());
+        }
+        assertThat(StaplerMethod.Helper.isMethod(method), is(false));
+    }
+
+    @Theory
+    public void given__publicMethodWithStaplerMethod__when__checking__then__staplerMethod(Method method) {
+        assumeThat(Modifier.isPublic(method.getModifiers()), is(true));
+        InterceptorAnnotation interceptor = null;
+        for (Annotation a: method.getDeclaredAnnotations()) {
+            interceptor = a.annotationType().getAnnotation(InterceptorAnnotation.class);
+            if (interceptor != null) {
+                break;
+            }
+        }
+        assumeThat(interceptor, notNullValue());
+        assertThat(StaplerMethod.Helper.isMethod(method), is(true));
+    }
+
+    public static class Probe {
+        private static Object getPrivateStaticNoAnnotation() {
+            return null;
+        }
+
+        static Object getPackageStaticNoAnnotation() {
+            return null;
+        }
+
+        protected static Object getProtectedStaticNoAnnotation() {
+            return null;
+        }
+
+        public static Object getPublicStaticNoAnnotation() {
+            return null;
+        }
+
+        private static void doPrivateStaticNoAnnotation(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        static void doPackageStaticNoAnnotation(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        protected static void doProtectedStaticNoAnnotation(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        public static void doPublicStaticNoAnnotation(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        private Object getPrivateNoAnnotation() {
+            return null;
+        }
+
+        static Object getPackageNoAnnotation() {
+            return null;
+        }
+
+        protected Object getProtectedNoAnnotation() {
+            return null;
+        }
+
+        public Object getPublicNoAnnotation() {
+            return null;
+        }
+
+        private void doPrivateNoAnnotation(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        void doPackageNoAnnotation(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        protected void doProtectedNoAnnotation(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        public void doPublicNoAnnotation(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        @StaplerPath
+        private static Object getPrivateStaticStaplerPath() {
+            return null;
+        }
+
+        @StaplerPath
+        static Object getPackageStaticStaplerPath() {
+            return null;
+        }
+
+        @StaplerPath
+        protected static Object getProtectedStaticStaplerPath() {
+            return null;
+        }
+
+        @StaplerPath
+        public static Object getPublicStaticStaplerPath() {
+            return null;
+        }
+
+        @StaplerPath
+        private static void doPrivateStaticStaplerPath(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        @StaplerPath
+        static void doPackageStaticStaplerPath(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        @StaplerPath
+        protected static void doProtectedStaticStaplerPath(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        @StaplerPath
+        public static void doPublicStaticStaplerPath(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        @StaplerPath
+        private Object getPrivateStaplerPath() {
+            return null;
+        }
+
+        @StaplerPath
+        static Object getPackageStaplerPath() {
+            return null;
+        }
+
+        @StaplerPath
+        protected Object getProtectedStaplerPath() {
+            return null;
+        }
+
+        @StaplerPath
+        public Object getPublicStaplerPath() {
+            return null;
+        }
+
+        @StaplerPath
+        private void doPrivateStaplerPath(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        @StaplerPath
+        void doPackageStaplerPath(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        @StaplerPath
+        protected void doProtectedStaplerPath(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        @StaplerPath
+        public void doPublicStaplerPath(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        @StaplerGET
+        private static Object getPrivateStaticStaplerGET() {
+            return null;
+        }
+
+        @StaplerGET
+        static Object getPackageStaticStaplerGET() {
+            return null;
+        }
+
+        @StaplerGET
+        protected static Object getProtectedStaticStaplerGET() {
+            return null;
+        }
+
+        @StaplerGET
+        public static Object getPublicStaticStaplerGET() {
+            return null;
+        }
+
+        @StaplerGET
+        private static void doPrivateStaticStaplerGET(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        @StaplerGET
+        static void doPackageStaticStaplerGET(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        @StaplerGET
+        protected static void doProtectedStaticStaplerGET(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        @StaplerGET
+        public static void doPublicStaticStaplerGET(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        @StaplerGET
+        private Object getPrivateStaplerGET() {
+            return null;
+        }
+
+        @StaplerGET
+        static Object getPackageStaplerGET() {
+            return null;
+        }
+
+        @StaplerGET
+        protected Object getProtectedStaplerGET() {
+            return null;
+        }
+
+        @StaplerGET
+        public Object getPublicStaplerGET() {
+            return null;
+        }
+
+        @StaplerGET
+        private void doPrivateStaplerGET(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        @StaplerGET
+        void doPackageStaplerGET(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        @StaplerGET
+        protected void doProtectedStaplerGET(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+        @StaplerGET
+        public void doPublicStaplerGET(StaplerRequest req, StaplerResponse rsp) {
+        }
+
+    }
+}

--- a/core/src/test/java/org/kohsuke/stapler/annotations/StaplerObjectHelperTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/annotations/StaplerObjectHelperTest.java
@@ -1,0 +1,272 @@
+package org.kohsuke.stapler.annotations;
+
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+public class StaplerObjectHelperTest {
+
+    @Test
+    public void given__class_without_annotation__when__checking__then__notObject() {
+        assertThat(StaplerObject.Helper.isObject(AbstractBaseClass.class), is(false));
+    }
+
+    @Test
+    public void given__class_without_annotation__when__checking__then__notHasObject() {
+        assertThat(StaplerObject.Helper.hasObject(AbstractBaseClass.class), is(false));
+    }
+
+    @Test
+    public void given__class_with_annotation__when__checking__then__isObject() {
+        assertThat(StaplerObject.Helper.isObject(AbstractSubclassWithAnnotation.class), is(true));
+    }
+
+    @Test
+    public void given__class_with_annotation__when__checking__then__hasObject() {
+        assertThat(StaplerObject.Helper.hasObject(AbstractSubclassWithAnnotation.class), is(true));
+    }
+
+    @Test
+    public void given__class_extends_annotation__when__checking__then__notObject() {
+        assertThat(StaplerObject.Helper.isObject(AbstractGrandclassWithoutAnnotation.class), is(false));
+    }
+
+    @Test
+    public void given__class_extends_annotation__when__checking__then__hasObject() {
+        assertThat(StaplerObject.Helper.hasObject(AbstractGrandclassWithoutAnnotation.class), is(true));
+    }
+
+    @Test
+    public void given__annotated_interface__when__checking__then__isObject() {
+        assertThat(StaplerObject.Helper.isObject(AnnotatedChildInterface.class), is(true));
+    }
+
+    @Test
+    public void given__annotated_interface__when__checking__then__hasObject() {
+        assertThat(StaplerObject.Helper.hasObject(AnnotatedChildInterface.class), is(true));
+    }
+
+    @Test
+    public void given__class_implements_annotated_interface__when__checking__then__notObject() {
+        assertThat(StaplerObject.Helper.isObject(ChildInterfaceImpl.class), is(false));
+    }
+
+    @Test
+    public void given__class_implements_annotated_interface__when__checking__then__hasObject() {
+        assertThat(StaplerObject.Helper.hasObject(ChildInterfaceImpl.class), is(true));
+    }
+
+    @Test
+    public void given__class_indirect_implements_annotated_interface__when__checking__then__notObject() {
+        assertThat(StaplerObject.Helper.isObject(GrandInterfaceImpl.class), is(false));
+    }
+
+    @Test
+    public void given__class_indirect_implements_annotated_interface__when__checking__then__hasObject() {
+        System.out.println(Arrays.asList(GrandInterfaceImpl.class.getInterfaces()));
+        assertThat(StaplerObject.Helper.hasObject(GrandInterfaceImpl.class), is(true));
+    }
+
+    public static List<Class<?>> declaringClasses(Method method) {
+        List<Class<?>> result = new ArrayList<>();
+        result.add(method.getDeclaringClass());
+        for (Method m: StaplerObject.Helper.declaredSuperMethods(method)) {
+            result.add(m.getDeclaringClass());
+        }
+        return result;
+    }
+
+
+
+    @Test
+    public void given__classDefiningMethodFromSuperAndInterfaces__when__listing_supers__orderReflectsPriority1() throws Exception {
+        assertThat(declaringClasses(A4.class.getMethod("m1")),
+                is(Arrays.asList(A4.class, A3.class, A1.class, B2.class, B1.class)));
+    }
+
+    @Test
+    public void given__classDefiningMethodFromSuperAndInterfaces__when__listing_supers__orderReflectsPriority2() throws Exception {
+        assertThat(declaringClasses(A4.class.getMethod("m2")),
+                is(Arrays.<Class<?>>asList(A3.class, A2.class, A1.class)));
+    }
+
+    @Test
+    public void given__classDefiningMethodFromSuperAndInterfaces__when__listing_supers__orderReflectsPriority3() throws Exception {
+        assertThat(declaringClasses(A4.class.getMethod("m3")),
+                is(Arrays.<Class<?>>asList(A3.class, A1.class)));
+    }
+
+    @Test
+    public void given__classDefiningMethodFromSuperAndInterfaces__when__listing_supers__orderReflectsPriority4() throws Exception {
+        assertThat(declaringClasses(A4.class.getMethod("m4")),
+                is(Arrays.<Class<?>>asList(A2.class, A1.class)));
+    }
+
+    @Test
+    public void given__classDefiningMethodFromSuperAndInterfaces__when__listing_supers__orderReflectsPriority5() throws Exception {
+        assertThat(declaringClasses(A4.class.getMethod("m5")),
+                is(Arrays.<Class<?>>asList(A4.class, C1.class, B1.class)));
+    }
+
+    @Test
+    public void given__classDefiningMethodFromSuperAndInterfaces__when__listing_supers__orderReflectsPriority6() throws Exception {
+        assertThat(declaringClasses(A4.class.getMethod("m6")),
+                is(Arrays.<Class<?>>asList(A4.class, B2.class, B1.class)));
+    }
+
+    public static abstract class AbstractBaseClass {}
+
+    @StaplerObject
+    public static abstract class AbstractSubclassWithAnnotation extends AbstractBaseClass {}
+
+    public static abstract class AbstractGrandclassWithoutAnnotation extends AbstractSubclassWithAnnotation {}
+
+    public interface BaseInterface {}
+
+    public interface ChildInterface extends BaseInterface {}
+
+    @StaplerObject
+    public interface AnnotatedChildInterface extends BaseInterface {}
+
+    public interface GrandInterface extends AnnotatedChildInterface {}
+
+    public static class ChildInterfaceImpl extends AbstractBaseClass implements AnnotatedChildInterface {}
+    public static class GrandInterfaceImpl extends AbstractBaseClass implements GrandInterface {}
+
+    public static abstract class A1 {
+        public abstract void m1();
+        public abstract void m2();
+        public abstract void m3();
+        public abstract void m4();
+        protected abstract void n1();
+        protected abstract void n2();
+        protected abstract void n3();
+        protected abstract void n4();
+        abstract void o1();
+        abstract void o2();
+        abstract void o3();
+        abstract void o4();
+        private void p1() {}
+        private void p2() {}
+        private void p3() {}
+        private void p4() {}
+    }
+
+    public static abstract class A2 extends A1 {
+        public abstract void m2();
+        public void m4() {}
+
+        public abstract void n3();
+
+        protected abstract void n4();
+
+        public abstract void o2();
+
+        protected abstract void o3();
+
+        abstract void o4();
+
+        private void p1() {}
+        private void p2() {}
+    }
+
+    public static class A3 extends A2 {
+
+        @Override
+        public void m1() {
+
+        }
+
+        @Override
+        public void m3() {
+
+        }
+
+        @Override
+        protected void n1() {
+
+        }
+
+        @Override
+        protected void n2() {
+
+        }
+
+        @Override
+        void o1() {
+
+        }
+
+        @Override
+        public void m2() {
+
+        }
+
+        @Override
+        public void n3() {
+
+        }
+
+        @Override
+        protected void n4() {
+
+        }
+
+        @Override
+        public void o2() {
+
+        }
+
+        @Override
+        protected void o3() {
+
+        }
+
+        @Override
+        void o4() {
+
+        }
+
+        private void p1() {
+        }
+
+        public void p2() {}
+    }
+
+    public interface B1 {
+        void m1();
+        void m5();
+        void m6();
+    }
+
+    public interface B2 extends B1{
+        void m1();
+        void m6();
+    }
+
+    public interface C1 {
+        void m5();
+    }
+
+    public static class A4 extends A3 implements B2, C1 {
+
+        public void m1() {
+
+        }
+
+        @Override
+        public void m5() {
+
+        }
+
+        @Override
+        public void m6() {
+
+        }
+    }
+}

--- a/core/src/test/java/org/kohsuke/stapler/annotations/StaplerPathHelperTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/annotations/StaplerPathHelperTest.java
@@ -20,6 +20,9 @@ import org.junit.experimental.theories.DataPoints;
 import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
 import org.junit.runner.RunWith;
+import org.kohsuke.stapler.Function;
+import org.kohsuke.stapler.FunctionList;
+import org.kohsuke.stapler.lang.Klass;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
@@ -31,6 +34,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeThat;
 import static org.junit.Assume.assumeTrue;
+import static org.kohsuke.stapler.annotations.StaplerPath.Helper.getPaths;
 
 @RunWith(Theories.class)
 public class StaplerPathHelperTest {
@@ -489,6 +493,16 @@ public class StaplerPathHelperTest {
     public void given__nonPublicMethod__when__isDynamic__then__notAPath(Method method) throws Exception {
         assumeThat(Modifier.isPublic(method.getModifiers()), is(false));
         assertThat(StaplerPath.Helper.isDynamic(method), is(false));
+    }
+
+    @Test
+    public void viaFunctions() throws Exception {
+        for (Function function: new FunctionList(Klass.java(Probe.class).getFunctions()).staplerPathMethods()) {
+            assertThat(StaplerPath.Helper.isPath(function), is(true));
+            Method m = method(function.getName());
+            assertThat(StaplerPath.Helper.isDynamic(function), is(StaplerPath.Helper.isDynamic(m)));
+            assertThat(StaplerPath.Helper.getPaths(function), is(getPaths(m)));
+        }
     }
 
     public static class Probe {

--- a/core/src/test/java/org/kohsuke/stapler/annotations/StaplerPathHelperTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/annotations/StaplerPathHelperTest.java
@@ -486,6 +486,12 @@ public class StaplerPathHelperTest {
     }
 
     @Test
+    public void given__navigatePrefixInferAnnotation__when__isPath__then__true()
+            throws Exception {
+        assertThat(StaplerPath.Helper.isPath(method("getInferAnnotation")), is(true));
+    }
+
+    @Test
     public void given__navigateNoPrefixInferAnnotation__when__getPaths__then__nameInferred()
             throws Exception {
         assertThat(StaplerPath.Helper.getPaths(method("inferAnnotation")),

--- a/core/src/test/java/org/kohsuke/stapler/annotations/StaplerPathHelperTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/annotations/StaplerPathHelperTest.java
@@ -1,0 +1,682 @@
+package org.kohsuke.stapler.annotations;
+
+import java.lang.annotation.Annotation;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.Test;
+import org.junit.experimental.theories.DataPoints;
+import org.junit.experimental.theories.Theories;
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeThat;
+import static org.junit.Assume.assumeTrue;
+
+@RunWith(Theories.class)
+public class StaplerPathHelperTest {
+
+    @DataPoints
+    public static Field[] someFields() {
+        return Probe.class.getDeclaredFields();
+    }
+
+    @DataPoints
+    public static Method[] someMethods() {
+        return Probe.class.getDeclaredMethods();
+    }
+
+    private static Field field(String name) throws NoSuchFieldException {
+        return Probe.class.getField(name);
+    }
+
+    private static Method method(String name) throws NoSuchFieldException {
+        for (Method m : Probe.class.getDeclaredMethods()) {
+            if (name.equals(m.getName())) {
+                return m;
+            }
+        }
+        fail("Cannot find a method called '" + name + "' on " + Probe.class);
+        return null;
+    }
+
+    @Test
+    public void helperIsAUtilityClass() throws Exception {
+        Constructor<StaplerPath.Helper> constructor = StaplerPath.Helper.class.getDeclaredConstructor();
+        constructor.setAccessible(true);
+        try {
+            constructor.newInstance();
+            fail("Construction of utility class instances should not be allowed");
+        } catch (InvocationTargetException e) {
+            assertThat(e.getCause(), instanceOf(IllegalAccessError.class));
+        }
+    }
+
+    @Theory
+    public void given__nonPublicField__when__checkingIfPath__then__notAPath(Field field) throws Exception {
+        assumeThat(Modifier.isPublic(field.getModifiers()), is(false));
+        assertThat(StaplerPath.Helper.isPath(field), is(false));
+    }
+
+    @Theory
+    public void given__publicFieldWithAnnotation__when__checkingIfPath__then__aPath(Field field) throws Exception {
+        assumeThat(Modifier.isPublic(field.getModifiers()), is(true));
+        assumeThat(field.getAnnotation(StaplerPath.class), notNullValue());
+        assumeThat(field.getAnnotation(StaplerPath.class).value(), not(is(StaplerPath.DYNAMIC)));
+        assertThat(field.getName(), StaplerPath.Helper.isPath(field), is(true));
+    }
+
+    @Theory
+    public void given__publicFieldWithoutAnnotation__when__checkingIfPath__then__notAPath(Field field) throws Exception {
+        assumeThat(Modifier.isPublic(field.getModifiers()), is(true));
+        assumeThat(field.getAnnotation(StaplerPath.class), nullValue());
+        assumeThat(field.getAnnotation(StaplerPaths.class), nullValue());
+        for (Annotation a: field.getAnnotations()) {
+            assumeThat(a.annotationType().getAnnotation(StaplerPath.Implicit.class), nullValue());
+        }
+        assertThat(field.getName(), StaplerPath.Helper.isPath(field), is(false));
+    }
+
+    @Theory
+    public void given__publicFieldWithAnnotations__when__checkingIfPath__then__aPath(Field field) throws Exception {
+        assumeThat(Modifier.isPublic(field.getModifiers()), is(true));
+        assumeThat(field.getAnnotation(StaplerPaths.class), notNullValue());
+        boolean haveOne = false;
+        boolean haveDynamic = false;
+        for (StaplerPath p: field.getAnnotation(StaplerPaths.class).value()) {
+            if (StaplerPath.DYNAMIC.equals(p.value())) {
+                haveDynamic = true;
+            } else {
+                haveOne = true;
+            }
+
+        }
+        assumeThat(haveOne || !haveDynamic, is(true));
+        assertThat(field.getName(), StaplerPath.Helper.isPath(field), is(true));
+    }
+
+    @Theory
+    public void given__publicFieldWithOnlyDynamicAnnotations__when__checkingIfPath__then__notAPath(Field field) throws Exception {
+        assumeThat(Modifier.isPublic(field.getModifiers()), is(true));
+        assumeThat(field.getAnnotation(StaplerPaths.class), notNullValue());
+        boolean haveOne = false;
+        boolean haveDynamic = false;
+        for (StaplerPath p: field.getAnnotation(StaplerPaths.class).value()) {
+            if (StaplerPath.DYNAMIC.equals(p.value())) {
+                haveDynamic = true;
+            } else {
+                haveOne = true;
+            }
+
+        }
+        assumeThat(haveDynamic && !haveOne, is(true));
+        assertThat(field.getName(), StaplerPath.Helper.isPath(field), is(false));
+    }
+
+    @Theory
+    public void given__nonPublicMethod__when__checkingIfPath__then__notAPath(Method method) throws Exception {
+        assumeThat(Modifier.isPublic(method.getModifiers()), is(false));
+        assertThat(StaplerPath.Helper.isPath(method), is(false));
+    }
+
+    @Theory
+    public void given__publicMethodWithAnnotation__when__checkingIfPath__then__aPath(Method method) throws Exception {
+        assumeThat(Modifier.isPublic(method.getModifiers()), is(true));
+        assumeThat(method.getAnnotation(StaplerPath.class), notNullValue());
+        assumeThat(method.getAnnotation(StaplerPath.class).value(), not(is(StaplerPath.DYNAMIC)));
+        assertThat(method.getName(), StaplerPath.Helper.isPath(method), is(true));
+    }
+
+    @Theory
+    public void given__publicMethodWithoutAnnotation__when__checkingIfPath__then__notAPath(Method method)
+            throws Exception {
+        assumeThat(Modifier.isPublic(method.getModifiers()), is(true));
+        assumeThat(method.getAnnotation(StaplerPath.class), nullValue());
+        assumeThat(method.getAnnotation(StaplerPaths.class), nullValue());
+        for (Annotation a : method.getAnnotations()) {
+            assumeThat(a.annotationType().getAnnotation(StaplerPath.Implicit.class), nullValue());
+        }
+        assertThat(method.getName(), StaplerPath.Helper.isPath(method), is(false));
+    }
+
+    @Theory
+    public void given__publicMethodWithoutImplied__when__checkingIfPath__then__aPath(Method method)
+            throws Exception {
+        assumeThat(Modifier.isPublic(method.getModifiers()), is(true));
+        assumeThat(method.getAnnotation(StaplerPath.class), nullValue());
+        assumeThat(method.getAnnotation(StaplerPaths.class), nullValue());
+        boolean haveImplied = false;
+        for (Annotation a : method.getAnnotations()) {
+            haveImplied = haveImplied || a.annotationType().getAnnotation(StaplerPath.Implicit.class) != null;
+        }
+        assumeThat(haveImplied, is(true));
+        assertThat(method.getName(), StaplerPath.Helper.isPath(method), is(true));
+    }
+
+    @Theory
+    public void given__publicMethodWithAnnotations__when__checkingIfPath__then__aPath(Method method) throws Exception {
+        assumeThat(Modifier.isPublic(method.getModifiers()), is(true));
+        assumeThat(method.getAnnotation(StaplerPaths.class), notNullValue());
+        assertThat(method.getName(), StaplerPath.Helper.isPath(method), is(true));
+    }
+
+    @Theory
+    public void given__publicMethodWithOnlyDynamicAnnotations__when__checkingIfPath__then__aPath(Method method)
+            throws Exception {
+        assumeThat(Modifier.isPublic(method.getModifiers()), is(true));
+        assumeThat(method.getAnnotation(StaplerPaths.class), notNullValue());
+        boolean haveStatic = false;
+        boolean haveDynamic = false;
+        for (StaplerPath p : method.getAnnotation(StaplerPaths.class).value()) {
+            if (StaplerPath.DYNAMIC.equals(p.value())) {
+                haveDynamic = true;
+            } else {
+                haveStatic = true;
+            }
+
+        }
+        assumeThat(haveDynamic && !haveStatic, is(true));
+        assertThat(method.getName(), StaplerPath.Helper.isPath(method), is(true));
+    }
+
+    @Test
+    public void given__publicFieldNoAnnotations__when__getPaths__then__noNames() throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(field("pubFieldSansAnnotation")),
+                StaplerPathHelperTest.<String>setEquivalence());
+    }
+
+    @Theory
+    public void given__nonPublicField__when__getPaths__then__noNames(Field field) throws Exception {
+        assumeThat(Modifier.isPublic(field.getModifiers()), is(false));
+        assertThat(StaplerPath.Helper.getPaths(field),
+                StaplerPathHelperTest.<String>setEquivalence());
+    }
+
+    @Test
+    public void given__publicFieldDefaultStaplerPath__when__getPaths__then__nameInferred() throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(field("pubFieldWithAnnotation")),
+                setEquivalence("pubFieldWithAnnotation"));
+    }
+
+    @Test
+    public void given__publicFieldCustomStaplerPath__when__getPaths__then__nameAsSpecified() throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(field("pubFieldWithAnnotationName")),
+                setEquivalence("named-public-field"));
+    }
+
+    @Test
+    public void given__publicFieldDynamicStaplerPath__when__getPaths__then__noNameInferred() throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(field("pubFieldWithAnnotationDynamic")),
+                StaplerPathHelperTest.<String>setEquivalence());
+    }
+
+    @Test
+    public void given__publicFieldIndexStaplerPath__when__getPaths__then__nameIndex() throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(field("pubFieldWithAnnotationIndex")),
+                setEquivalence(""));
+    }
+
+    @Test
+    public void given__publicFieldMultipleStaplerPath__when__getPaths__then__namesAsSpecified() throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(field("pubFieldWithAnnotationMultiple")),
+                setEquivalence("pubFieldWithAnnotationMultiple", "alternative-path"));
+    }
+
+    @Test
+    public void given__publicFieldMultipleStaplerPathWithDynamic__when__getPaths__then__namesAsSpecified() throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(field("pubFieldWithAnnotationMultipleAndDynamic")),
+                setEquivalence("pubFieldWithAnnotationMultipleAndDynamic", "alternative-path"));
+    }
+
+    @Test
+    public void given__publicFieldEmptyStaplerPaths__when__getPaths__then__noNamesInferred() throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(field("pubFieldWithAnnotationEmpty")),
+                setEquivalence("pubFieldWithAnnotationEmpty"));
+    }
+
+    @Test
+    public void given__publicFieldImplicit__when__getPaths__then__nameInferred() throws Exception {
+        assertThat(StaplerPath.Helper.isPath(field("pubFieldWithImplicit")), is(true));
+        assertThat(StaplerPath.Helper.getPaths(field("pubFieldWithImplicit")),
+                setEquivalence("pubFieldWithImplicit"));
+    }
+
+    @Test
+    public void given__publicFieldImplicitAndPathInferred__when__getPaths__then__nameInferred() throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(field("pubFieldWithImplicitAndPath")),
+                setEquivalence("pubFieldWithImplicitAndPath"));
+    }
+
+    @Test
+    public void given__publicFieldImplicitAndPathSpecified__when__getPaths__then__nameSpecified() throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(field("pubFieldWithImplicitAndPathName")),
+                setEquivalence("named-not-inferred"));
+    }
+
+    @Test
+    public void given__publicFieldImplicitAndPathsSpecified__when__getPaths__then__namesSpecified() throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(field("pubFieldWithImplicitAndPathNames")),
+                setEquivalence("", "named-not-inferred"));
+    }
+
+    @Test
+    public void given__publicMethodNoAnnotations__when__getPaths__then__noNames() throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("doPublicSansAnnotation")),
+                StaplerPathHelperTest.<String>setEquivalence());
+    }
+
+    @Theory
+    public void given__nonPublicMethod__when__getPaths__then__noNames(Method method) throws Exception {
+        assumeThat(Modifier.isPublic(method.getModifiers()), is(false));
+        assertThat(StaplerPath.Helper.getPaths(method),
+                StaplerPathHelperTest.<String>setEquivalence());
+    }
+
+    @Test
+    public void given__publicMethodPathInferred__when__getPaths__then__nameInferredWithPrefixRemoved()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("doPublicWithAnnotation")),
+                setEquivalence("publicWithAnnotation"));
+    }
+
+    @Test
+    public void given__publicMethodPathInferredNoPrefix__when__getPaths__then__nameInferred()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("publicWithAnnotation")),
+                setEquivalence("publicWithAnnotation"));
+    }
+
+    @Test
+    public void given__publicMethodPathInferredPrefixShortestName__when__getPaths__then__nameInferred()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("doA")),
+                setEquivalence("a"));
+    }
+
+    @Test
+    public void given__publicMethodPathInferredPrefixShortName__when__getPaths__then__nameInferred()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("doAt")),
+                setEquivalence("at"));
+    }
+
+    @Test
+    public void given__publicMethodPathImpliedPrefixTooShortName__when__getPaths__then__nameInferred()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("js")),
+                setEquivalence("js"));
+    }
+
+    @Test
+    public void given__publicMethodPathImpliedPrefixShortestName__when__getPaths__then__nameInferred()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("jsA")),
+                setEquivalence("a"));
+    }
+
+    @Test
+    public void given__publicMethodPathImpliedPrefixShortName__when__getPaths__then__nameInferred()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("jsAt")),
+                setEquivalence("at"));
+    }
+
+    @Test
+    public void given__publicMethodPathSpecified__when__getPaths__then__nameAsSpecified()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("doPublicWithAnnotationName")),
+                setEquivalence("named-public-method"));
+    }
+
+    @Test
+    public void given__publicMethodPathIndex__when__getPaths__then__nameIndex()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("doPublicWithAnnotationIndex")),
+                setEquivalence(StaplerPath.INDEX));
+    }
+
+    @Test
+    public void given__publicMethodPathDynamic__when__getPaths__then__nameEmpty()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("doPublicWithAnnotationDynamic")),
+                StaplerPathHelperTest.<String>setEquivalence());
+    }
+
+    @Test
+    public void given__publicMethodPathsEmpty__when__getPaths__then__nameInferred()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("doPublicWithAnnotationsEmpty")),
+                setEquivalence("publicWithAnnotationsEmpty"));
+    }
+
+    @Test
+    public void given__publicMethodPaths__when__getPaths__then__nameInferredAndSpecified()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("doPublicWithAnnotations")),
+                setEquivalence("publicWithAnnotations", "alternative"));
+        assertThat(StaplerPath.Helper.isDynamic(method("doPublicWithAnnotations")),
+                is(true));
+    }
+
+    @Test
+    public void given__publicMethodPathsDynamic__when__getPaths__then__nameEmpty()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("doPublicWithDynamicAnnotations")),
+                StaplerPathHelperTest.<String>setEquivalence());
+    }
+
+    @Test
+    public void given__publicGetMethod__when__getPaths__then__nameInferred()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("doGet")),
+                setEquivalence("get"));
+    }
+
+    @Test
+    public void given__publicPostMethod__when__getPaths__then__nameInferred()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("doPost")),
+                setEquivalence("post"));
+    }
+
+    @Test
+    public void given__publicPutMethod__when__getPaths__then__nameInferred()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("doPut")),
+                setEquivalence("put"));
+    }
+
+    @Test
+    public void given__publicCustomMethod__when__getPaths__then__nameInferred()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("doGetAlt")),
+                setEquivalence("getAlt"));
+    }
+
+    @Test
+    public void given__publicGetIndexMethod__when__getPaths__then__nameIndex()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("doGetIndex")),
+                setEquivalence(StaplerPath.INDEX));
+    }
+
+    @Test
+    public void given__publicPostIndexMethod__when__getPaths__then__nameInferred()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("doPostIndex")),
+                setEquivalence(StaplerPath.INDEX));
+    }
+
+    @Test
+    public void given__differentInferredPrefixes__when__noPrefix__then__nameVerbatim()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("manyPrefixes")),
+                setEquivalence("manyPrefixes"));
+    }
+
+    @Test
+    public void given__differentInferredPrefixes__when__firstPrefix__then__nameInferred()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("doManyPrefixes")),
+                setEquivalence("manyPrefixes"));
+    }
+
+    @Test
+    public void given__differentInferredPrefixes__when__secondPrefix__then__nameInferred()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("jsManyPrefixes")),
+                setEquivalence("manyPrefixes"));
+    }
+
+    @Test
+    public void given__differentInferredPrefixes__when__duplicatePrefix__then__onlyFirstRemoved()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("jsDoManyPrefixes")),
+                setEquivalence("doManyPrefixes"));
+        assertThat(StaplerPath.Helper.getPaths(method("doJsManyPrefixes")),
+                setEquivalence("jsManyPrefixes"));
+    }
+
+    @Test
+    public void given__repeatedPrefixes__when__getPaths__then__onlyFirstRemoved()
+            throws Exception {
+        assertThat(StaplerPath.Helper.getPaths(method("doDoManyPrefixes")),
+                setEquivalence("doManyPrefixes"));
+        assertThat(StaplerPath.Helper.getPaths(method("jsJsManyPrefixes")),
+                setEquivalence("jsManyPrefixes"));
+    }
+
+    @Test
+    public void given__publicMethodPathNotDynamic__when__isDynamic__then__false()
+            throws Exception {
+        assertThat(StaplerPath.Helper.isDynamic(method("doPublicWithAnnotation")), is(false));
+        assertThat(StaplerPath.Helper.isDynamic(method("doPublicWithAnnotationName")), is(false));
+        assertThat(StaplerPath.Helper.isDynamic(method("doPublicWithAnnotationIndex")), is(false));
+    }
+
+    @Test
+    public void given__publicMethodPathDynamic__when__isDynamic__then__true()
+            throws Exception {
+        assertThat(StaplerPath.Helper.isDynamic(method("doPublicWithAnnotationDynamic")), is(true));
+    }
+
+    @Test
+    public void given__publicMethodPathsDynamic__when__isDynamic__then__true()
+            throws Exception {
+        assertThat(StaplerPath.Helper.isDynamic(method("doPublicWithDynamicAnnotations")), is(true));
+    }
+
+    @Theory
+    public void given__nonPublicMethod__when__isDynamic__then__notAPath(Method method) throws Exception {
+        assumeThat(Modifier.isPublic(method.getModifiers()), is(false));
+        assertThat(StaplerPath.Helper.isDynamic(method), is(false));
+    }
+
+    public static class Probe {
+
+        protected String protFieldSansAnnotation;
+        @StaplerPath
+        protected String protFieldWithAnnotation;
+        public String pubFieldSansAnnotation;
+        @StaplerPath
+        public String pubFieldWithAnnotation;
+        @StaplerPath("named-public-field")
+        public String pubFieldWithAnnotationName;
+        @StaplerPath(StaplerPath.DYNAMIC)
+        public String pubFieldWithAnnotationDynamic;
+        @StaplerPath(StaplerPath.INDEX)
+        public String pubFieldWithAnnotationIndex;
+        @StaplerPaths({
+                              @StaplerPath(),
+                              @StaplerPath("alternative-path")
+                      })
+        public String pubFieldWithAnnotationMultiple;
+        @StaplerPaths({@StaplerPath(), @StaplerPath(StaplerPath.DYNAMIC), @StaplerPath("alternative-path")})
+        public String pubFieldWithAnnotationMultipleAndDynamic;
+        @StaplerPaths({})
+        public String pubFieldWithAnnotationEmpty;
+        @CustomStaplerImplicitField
+        public String pubFieldWithImplicit;
+        @CustomStaplerImplicitField
+        @StaplerPath
+        public String pubFieldWithImplicitAndPath;
+        @CustomStaplerImplicitField
+        @StaplerPath("named-not-inferred")
+        public String pubFieldWithImplicitAndPathName;
+        @CustomStaplerImplicitField
+        @StaplerPaths({@StaplerPath(StaplerPath.INDEX), @StaplerPath("named-not-inferred")})
+        public String pubFieldWithImplicitAndPathNames;
+        @Deprecated
+        public String deprecated;
+        @StaplerPaths({})
+        public String emptyPaths;
+        @StaplerPaths({@StaplerPath(StaplerPath.DYNAMIC)})
+        public String dynamicPaths;
+        @StaplerPaths({@StaplerPath(StaplerPath.DYNAMIC), @StaplerPath(StaplerPath.DYNAMIC)})
+        public String manyDynamicPaths;
+        @StaplerPaths({@StaplerPath(),@StaplerPath(StaplerPath.DYNAMIC)})
+        public String manyPaths;
+
+        protected void doProtectedSansAnnotation() {
+        }
+
+        @StaplerPath
+        protected void doProtectedWithAnnotation() {
+        }
+
+        public void doPublicSansAnnotation() {
+        }
+
+        @StaplerPath
+        public void doPublicWithAnnotation() {
+        }
+
+        @StaplerPath
+        public void publicWithAnnotation() {
+        }
+
+        @StaplerPath
+        public void doA() {
+        }
+
+        @StaplerPath
+        public void doAt() {
+        }
+
+        @StaplerRMI
+        public void js() {
+        }
+
+        @StaplerRMI
+        public void jsA() {
+        }
+
+        @StaplerRMI
+        public void jsAt() {
+        }
+
+        @StaplerPath("named-public-method")
+        public void doPublicWithAnnotationName() {
+        }
+
+        @StaplerPath(StaplerPath.INDEX)
+        public void doPublicWithAnnotationIndex() {
+        }
+
+        @StaplerPath(StaplerPath.DYNAMIC)
+        public void doPublicWithAnnotationDynamic() {
+        }
+
+        @StaplerPaths({})
+        public void doPublicWithAnnotationsEmpty() {
+        }
+
+        @StaplerPaths({@StaplerPath, @StaplerPath("alternative"), @StaplerPath(StaplerPath.DYNAMIC)})
+        public void doPublicWithAnnotations() {
+        }
+
+        @StaplerPaths({@StaplerPath(StaplerPath.DYNAMIC), @StaplerPath(StaplerPath.DYNAMIC)})
+        public void doPublicWithDynamicAnnotations() {
+        }
+
+        @StaplerGET
+        public void doGet() {}
+        @StaplerPOST
+        public void doPost() {}
+        @StaplerPUT
+        public void doPut() {}
+        @StaplerMethod("GET")
+        public void doGetAlt() {}
+
+        @StaplerGET
+        @StaplerPath(StaplerPath.INDEX)
+        public void doGetIndex() {
+        }
+
+        @StaplerPOST
+        @StaplerPath(StaplerPath.INDEX)
+        public void doPostIndex() {
+        }
+
+        @StaplerGET
+        @StaplerRMI
+        public void manyPrefixes() {
+
+        }
+        @StaplerGET
+        @StaplerRMI
+        public void doManyPrefixes() {
+
+        }
+        @StaplerGET
+        @StaplerRMI
+        public void jsManyPrefixes() {
+
+        }
+        @StaplerGET
+        @StaplerRMI
+        public void doJsManyPrefixes() {
+
+        }
+        @StaplerGET
+        @StaplerRMI
+        public void jsDoManyPrefixes() {
+
+        }
+        @StaplerGET
+        public void doDoManyPrefixes() {
+
+        }
+        @StaplerRMI
+        public void jsJsManyPrefixes() {
+
+        }
+    }
+
+    @Target({FIELD})
+    @Retention(RUNTIME)
+    @StaplerPath.Implicit
+    @Documented
+    public @interface CustomStaplerImplicitField {
+    }
+
+
+    private static <T> Matcher<? super Iterable<T>> setEquivalence(final T... items) {
+        return new BaseMatcher<Iterable<T>>() {
+            @Override
+            public boolean matches(Object item) {
+                Set<T> expected = new HashSet<>(Arrays.asList(items));
+                Set<T> actual = new HashSet<>(expected.size());
+                for (T i : (Iterable<T>) item) {
+                    actual.add(i);
+                }
+                return expected.equals(actual);
+            }
+
+            @Override
+            public void describeTo(Description description) {
+                description.appendValueList("an iterable over [", ",", "]", items);
+            }
+        };
+    }
+
+}

--- a/jruby/src/main/java/org/kohsuke/stapler/jelly/jruby/RubyMethodRef.java
+++ b/jruby/src/main/java/org/kohsuke/stapler/jelly/jruby/RubyMethodRef.java
@@ -57,6 +57,12 @@ public class RubyMethodRef extends MethodRef {
     }
 
     @Override
+    public Annotation[] getAnnotations() {
+        // TODO: what's the equivalent in JRuby?
+        return super.getAnnotations();
+    }
+
+    @Override
     public Object invoke(Object _this, Object... args) throws InvocationTargetException, IllegalAccessException {
         IRubyObject[] argList = new IRubyObject[args.length];
         for (int i=0; i<args.length; i++)


### PR DESCRIPTION
See [this thread on the jenkins-dev mailing list](https://groups.google.com/forum/#!topic/jenkinsci-dev/UrVVT8wbHIE) for context.

@reviewbybees @jenkinsci/code-reviewers 

Here is the initial proposed annotations.

ToDo:

- [x] Wire up the `@StaplerPath`, `@StaplerRMI` and `@StaplerObject`, annotations so that they actually work (the `@StaplerGET` / `@StaplerContent` / etc annotations work out of the box because they build on top of the `@InterceptorAnnotation` meta-annotation. The `@StaplerFacet` and `@StaplerFragment` annotations are documentation only - retained with runtime retention as some consistency checks possible with these may need to be implemented via a unit test generator. 
- [ ] Implement some annotation processor based consistency checks
- [ ] Implement some automated unit test generator for the additional checks that cannot be performed by an annotation processor
  - [ ] Investigate whether the unit test generator could be implemented as an annotation processor
- [x] Tests for the new annotations
- [ ] Documentation