### PR TITLE
JENKINS-45099 special JSON characters are not consistently quoted

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -47,6 +47,11 @@
       <version>1.7.0</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.5</version>
+    </dependency>
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>1.3.1</version>

--- a/core/src/main/java/org/kohsuke/stapler/export/JSONDataWriter.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/JSONDataWriter.java
@@ -23,6 +23,8 @@
 
 package org.kohsuke.stapler.export;
 
+import org.apache.commons.lang3.StringEscapeUtils;
+
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.Writer;
@@ -103,17 +105,7 @@ class JSONDataWriter implements DataWriter {
     public void value(String v) throws IOException {
         StringBuilder buf = new StringBuilder(v.length());
         buf.append('\"');
-        for( int i=0; i<v.length(); i++ ) {
-            char c = v.charAt(i);
-            switch(c) {
-            case '"':   buf.append("\\\"");break;
-            case '\\':  buf.append("\\\\");break;
-            case '\n':  buf.append("\\n");break;
-            case '\r':  buf.append("\\r");break;
-            case '\t':  buf.append("\\t");break;
-            default:    buf.append(c);break;
-            }
-        }
+        buf.append(StringEscapeUtils.escapeJson(v));
         buf.append('\"');
         data(buf.toString());
     }

--- a/core/src/test/java/org/kohsuke/stapler/export/JSONDataWriterTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/JSONDataWriterTest.java
@@ -5,6 +5,8 @@ import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.List;
 
+import net.sf.json.JSONObject;
+import net.sf.json.util.JSONUtils;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
@@ -16,6 +18,20 @@ public class JSONDataWriterTest {
         Model<T> model = new ModelBuilder().get(clazz);
         model.writeTo(bean, Flavor.JSON.createDataWriter(bean, w, config));
         return w.toString();
+    }
+
+    @Test
+    public void testJsonCharacters() throws Exception {
+        String serialize = serialize(new JsonCharacters(), JsonCharacters.class);
+        assertEquals("{\"_class\":\"JsonCharacters\",\"value\":\"\\\"'\\/[]{}\\\\\"}", serialize);
+    }
+
+    @ExportedBean
+    public static class JsonCharacters {
+        @Exported
+        public String getValue() {
+            return "\"'/[]{}\\";
+        }
     }
 
     @ExportedBean public static class X {

--- a/core/src/test/java/org/kohsuke/stapler/export/JSONDataWriterTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/JSONDataWriterTest.java
@@ -5,8 +5,6 @@ import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.List;
 
-import net.sf.json.JSONObject;
-import net.sf.json.util.JSONUtils;
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 

--- a/core/src/test/java/org/kohsuke/stapler/export/JSONDataWriterTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/JSONDataWriterTest.java
@@ -22,6 +22,8 @@ public class JSONDataWriterTest {
     public void testJsonCharacters() throws Exception {
         String serialize = serialize(new JsonCharacters(), JsonCharacters.class);
         assertEquals("{\"_class\":\"JsonCharacters\",\"value\":\"\\\"'\\/[]{}\\\\\"}", serialize);
+        final String expected = "{\"_class\":\"JsonCharacters2\",\"value\":\"\\\"foo\\\" isn't \\\"bar\\\". specials: \\b\\r\\n\\f\\t\\\\\\/\"}";
+        assertEquals(expected, serialize(new JsonCharacters2(), JsonCharacters2.class));
     }
 
     @ExportedBean
@@ -29,6 +31,14 @@ public class JSONDataWriterTest {
         @Exported
         public String getValue() {
             return "\"'/[]{}\\";
+        }
+    }
+
+    @ExportedBean
+    public static class JsonCharacters2 {
+        @Exported
+        public String getValue() {
+            return "\"foo\" isn't \"bar\". specials: \b\r\n\f\t\\/";
         }
     }
 

--- a/core/src/test/java/org/kohsuke/stapler/export/JSONDataWriterTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/export/JSONDataWriterTest.java
@@ -20,10 +20,11 @@ public class JSONDataWriterTest {
 
     @Test
     public void testJsonCharacters() throws Exception {
-        String serialize = serialize(new JsonCharacters(), JsonCharacters.class);
-        assertEquals("{\"_class\":\"JsonCharacters\",\"value\":\"\\\"'\\/[]{}\\\\\"}", serialize);
-        final String expected = "{\"_class\":\"JsonCharacters2\",\"value\":\"\\\"foo\\\" isn't \\\"bar\\\". specials: \\b\\r\\n\\f\\t\\\\\\/\"}";
-        assertEquals(expected, serialize(new JsonCharacters2(), JsonCharacters2.class));
+        String jsonCharactersExpected = "{\"_class\":\"JsonCharacters\",\"value\":\"\\\"'\\/[]{}\\\\\"}";
+        assertEquals(jsonCharactersExpected, serialize(new JsonCharacters(), JsonCharacters.class));
+
+        final String jsonCharacters2Expected = "{\"_class\":\"JsonCharacters2\",\"value\":\"\\\"foo\\\" isn't \\\"bar\\\". specials: \\b\\r\\n\\f\\t\\\\\\/\"}";
+        assertEquals(jsonCharacters2Expected, serialize(new JsonCharacters2(), JsonCharacters2.class));
     }
 
     @ExportedBean


### PR DESCRIPTION
Special JSON characters such as `[` and `]` were not consistently quoted when writing to the output stream, resulting in invalid JSON.

This change uses `commons-lang` v3's `org.apache.commons.lang3.StringEscapeUtils#escapeJson` which ensures that all special JSON characters and control characters are encoded correctly. 

PTAL @reviewbybees @jglick @vivek 