### PR TITLE
[JENKINS-45903] Switch to Files.new(Input|Output)Stream(...) to avoid file handle leak

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/config/ConfigurationLoader.java
+++ b/core/src/main/java/org/kohsuke/stapler/config/ConfigurationLoader.java
@@ -1,11 +1,13 @@
 package org.kohsuke.stapler.config;
 
 import com.google.common.base.Function;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import org.apache.commons.beanutils.ConvertUtils;
 
 import java.beans.Introspector;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
@@ -60,12 +62,9 @@ public class ConfigurationLoader {
 
     private static Properties load(File f) throws IOException {
         Properties config = new Properties();
-        FileInputStream in = new FileInputStream(f);
-        try {
+        try (InputStream in = Files.newInputStream(f.toPath(), StandardOpenOption.READ)){
             config.load(in);
             return config;
-        } finally {
-            in.close();
         }
     }
 

--- a/core/src/main/java/org/kohsuke/stapler/framework/io/AtomicFileWriter.java
+++ b/core/src/main/java/org/kohsuke/stapler/framework/io/AtomicFileWriter.java
@@ -29,7 +29,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.BufferedWriter;
 import java.io.OutputStreamWriter;
-import java.io.FileOutputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 
 /**
  * Buffered {@link FileWriter} that uses UTF-8.
@@ -49,7 +50,12 @@ public class AtomicFileWriter extends Writer {
     public AtomicFileWriter(File f) throws IOException {
         tmpFile = File.createTempFile("atomic",null,f.getParentFile());
         destFile = f;
-        core = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(tmpFile),"UTF-8"));
+        core = new BufferedWriter(new OutputStreamWriter(Files.newOutputStream(
+                tmpFile.toPath(),
+                StandardOpenOption.CREATE,
+                StandardOpenOption.TRUNCATE_EXISTING, // empty file already created by createTempFile
+                StandardOpenOption.WRITE
+        ),"UTF-8"));
     }
 
     public void write(int c) throws IOException {

--- a/core/src/main/java/org/kohsuke/stapler/framework/io/LargeText.java
+++ b/core/src/main/java/org/kohsuke/stapler/framework/io/LargeText.java
@@ -25,7 +25,8 @@
 
 package org.kohsuke.stapler.framework.io;
 
-import org.apache.commons.io.IOUtils;
+import java.nio.file.Files;
+import java.nio.file.StandardOpenOption;
 import org.apache.commons.io.output.CountingOutputStream;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
@@ -34,7 +35,6 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -427,7 +427,7 @@ public class LargeText {
         private final GZIPInputStream gz;
 
         public GzipAwareSession(File file) throws IOException {
-            this.gz = new GZIPInputStream(new FileInputStream(file));
+            this.gz = new GZIPInputStream(Files.newInputStream(file.toPath(), StandardOpenOption.READ));
         }
 
         public void close() throws IOException {
@@ -455,14 +455,11 @@ public class LargeText {
          * @return true, if the first two bytes are the GZIP magic number.
          */
         public static boolean isGzipStream(File file) {
-            DataInputStream in = null;
-            try {
-                in = new DataInputStream(new FileInputStream(file));
-                return in.readShort()==0x1F8B;
+            try (InputStream in = Files.newInputStream(file.toPath(), StandardOpenOption.READ);
+                 DataInputStream din = new DataInputStream(in)) {
+                return din.readShort()==0x1F8B;
             } catch (IOException ex) {
                 return false;
-            } finally {
-                IOUtils.closeQuietly(in);
             }
         }
         


### PR DESCRIPTION
See [JDK-8080225](https://bugs.openjdk.java.net/browse/JDK-8080225) and [JENKINS-45903](https://issues.jenkins-ci.org/browse/JENKINS-45903)

@reviewbybees