### PR TITLE
[Performance] Export Model constructor throws exceptions on very hot paths

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/export/ModelBuilder.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/ModelBuilder.java
@@ -42,12 +42,22 @@ public class ModelBuilder {
     /*package*/ final Map<Class, Model> models = new ConcurrentHashMap<Class, Model>();
 
     public <T> Model<T> get(Class<T> type) throws NotExportableException {
+        if (type.getAnnotation(ExportedBean.class) == null) {
+            throw new NotExportableException(type);
+        }
         return get(type, null, null);
     }
 
-    public <T> Model<T> get(Class<T> type, @CheckForNull Class<?> propertyOwner, @Nullable String property) throws NotExportableException {
+    public <T> Model<T> get(Class<T> type, @CheckForNull Class<?> propertyOwner, @Nullable String property) {
+        if (type.getAnnotation(ExportedBean.class) == null) {
+            throw new NotExportableException(type);
+        }
+        return getOrNull(type, propertyOwner, property);
+    }
+
+    public <T> Model<T> getOrNull(Class<T> type, @CheckForNull Class<?> propertyOwner, @Nullable String property) throws NotExportableException {
         Model m = models.get(type);
-        if(m==null) {
+        if(m==null && type.getAnnotation(ExportedBean.class) != null) {
             m = new Model<T>(this, type, propertyOwner, property);
         }
         return m;

--- a/core/src/main/java/org/kohsuke/stapler/export/ModelBuilder.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/ModelBuilder.java
@@ -47,6 +47,10 @@ public class ModelBuilder {
         return get(type, null, null);
     }
 
+    /**
+     * @throws NotExportableException if type is not exportable
+     * @return model
+     */
     @Nonnull
     public <T> Model<T> get(Class<T> type, @CheckForNull Class<?> propertyOwner, @Nullable String property) throws NotExportableException {
         Model<T> model = getOrNull(type, propertyOwner, property);
@@ -56,6 +60,12 @@ public class ModelBuilder {
         return model;
     }
 
+    /**
+     * Instead of throwing {@link NotExportableException} this method will return null
+     * This should be used on hot paths where throwing the exception and catching it would incur a performance hit
+     * @return model
+     * @since 1.253
+     */
     @CheckForNull
     public <T> Model<T> getOrNull(Class<T> type, @CheckForNull Class<?> propertyOwner, @Nullable String property) {
         Model<T> m = models.get(type);

--- a/core/src/main/java/org/kohsuke/stapler/export/ModelBuilder.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/ModelBuilder.java
@@ -26,6 +26,7 @@ package org.kohsuke.stapler.export;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 /**
@@ -36,27 +37,28 @@ import javax.annotation.Nullable;
 public class ModelBuilder {
     /**
      * Instantiated {@link Model}s.
-     * Registration happens in {@link Model#Model(ModelBuilder,Class)} so that cyclic references
+     * Registration happens in {@link Model#Model(ModelBuilder, Class, Class, String)} so that cyclic references
      * are handled correctly.
      */
     /*package*/ final Map<Class, Model> models = new ConcurrentHashMap<Class, Model>();
 
+    @Nonnull
     public <T> Model<T> get(Class<T> type) throws NotExportableException {
-        if (type.getAnnotation(ExportedBean.class) == null) {
-            throw new NotExportableException(type);
-        }
         return get(type, null, null);
     }
 
-    public <T> Model<T> get(Class<T> type, @CheckForNull Class<?> propertyOwner, @Nullable String property) {
-        if (type.getAnnotation(ExportedBean.class) == null) {
+    @Nonnull
+    public <T> Model<T> get(Class<T> type, @CheckForNull Class<?> propertyOwner, @Nullable String property) throws NotExportableException {
+        Model<T> model = getOrNull(type, propertyOwner, property);
+        if (model == null) {
             throw new NotExportableException(type);
         }
-        return getOrNull(type, propertyOwner, property);
+        return model;
     }
 
-    public <T> Model<T> getOrNull(Class<T> type, @CheckForNull Class<?> propertyOwner, @Nullable String property) throws NotExportableException {
-        Model m = models.get(type);
+    @CheckForNull
+    public <T> Model<T> getOrNull(Class<T> type, @CheckForNull Class<?> propertyOwner, @Nullable String property) {
+        Model<T> m = models.get(type);
         if(m==null && type.getAnnotation(ExportedBean.class) != null) {
             m = new Model<T>(this, type, propertyOwner, property);
         }

--- a/core/src/main/java/org/kohsuke/stapler/export/Property.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Property.java
@@ -198,6 +198,12 @@ public abstract class Property implements Comparable<Property> {
 
         Class c = value.getClass();
 
+        try {
+            writer.type(expected, value.getClass());
+        } catch (AbstractMethodError _) {
+            // legacy impl that doesn't understand it
+        }
+
         if (c.getAnnotation(ExportedBean.class) == null) {
             handleNotExportable(expected, value, pruner, writer, skipIfFail, c);
         } else {
@@ -213,12 +219,6 @@ public abstract class Property implements Comparable<Property> {
                 handleNotExportable(expected, value, pruner, writer, skipIfFail, c);
                 return;
             }
-        }
-
-        try {
-            writer.type(expected, value.getClass());
-        } catch (AbstractMethodError _) {
-            // legacy impl that doesn't understand it
         }
     }
 

--- a/core/src/main/java/org/kohsuke/stapler/export/Property.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Property.java
@@ -131,7 +131,7 @@ public abstract class Property implements Comparable<Property> {
         TreePruner child = pruner.accept(object, this);
         if (child==null)        return;
 
-        Object d = writer.getExportConfig().getExportInterceptor().getValue(this,object,writer.getExportConfig());
+        Object d = writer.getExportConfig().getExportInterceptor().getValue(this,object, writer.getExportConfig());
 
         if ((d==null && skipNull) || d == ExportInterceptor.SKIP) { // don't write anything
             return;

--- a/core/src/main/java/org/kohsuke/stapler/export/Property.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Property.java
@@ -198,6 +198,12 @@ public abstract class Property implements Comparable<Property> {
 
         Class c = value.getClass();
 
+        try {
+            writer.type(expected, value.getClass());
+        } catch (AbstractMethodError _) {
+            // legacy impl that doesn't understand it
+        }
+
         Model model = owner.getOrNull(c, parent.type, name);
         if (model == null) {
             if(STRING_TYPES.contains(c)) {
@@ -297,11 +303,6 @@ public abstract class Property implements Comparable<Property> {
 
             throw new NotExportableException(c);
         } else {
-            try {
-                writer.type(expected, value.getClass());
-            } catch (AbstractMethodError _) {
-                // legacy impl that doesn't understand it
-            }
             writer.startObject();
             model.writeNestedObjectTo(value, pruner, writer);
             writer.endObject();

--- a/core/src/main/java/org/kohsuke/stapler/export/Property.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Property.java
@@ -198,106 +198,21 @@ public abstract class Property implements Comparable<Property> {
 
         Class c = value.getClass();
 
-        Model model;
-        try {
-            model = owner.get(c, parent.type, name);
-        } catch (NotExportableException ex) {
-            if(STRING_TYPES.contains(c)) {
-                writer.value(value.toString());
-                return;
-            }
-            if(PRIMITIVE_TYPES.contains(c)) {
-                writer.valuePrimitive(value);
-                return;
-            }
-            Class act = c.getComponentType();
-            if (act !=null) { // array
-                Range r = pruner.getRange();
-                writer.startArray();
-                if (value instanceof Object[]) {
-                    // typical case
-                    for (Object item : r.apply((Object[]) value)) {
-                        writeBuffered(act, item, pruner, writer);
-                    }
-                } else {
-                    // more generic case
-                    int len = Math.min(r.max, Array.getLength(value));
-                    for (int i=r.min; i<len; i++) {
-                        writeBuffered(act, Array.get(value, i), pruner, writer);
-                    }
+        if (c.getAnnotation(ExportedBean.class) == null) {
+            handleNotExportable(expected, value, pruner, writer, skipIfFail, c);
+        } else {
+            try {
+                Model model = owner.getOrNull(c, parent.type, name);
+                if (model == null) {
+                    throw new NotExportableException(c);
                 }
-                writer.endArray();
-                return;
-            }
-            if(value instanceof Iterable) {
-                writer.startArray();
-                Type expectedItemType = Types.getTypeArgument(expected, 0, null);
-                for (Object item : pruner.getRange().apply((Iterable) value)) {
-                    writeBuffered(expectedItemType, item, pruner, writer);
-                }
-                writer.endArray();
-                return;
-            }
-            if(value instanceof Map) {
-                if (verboseMap!=null) {// verbose form
-                    writer.startArray();
-                    for (Map.Entry e : ((Map<?,?>) value).entrySet()) {
-                        BufferedDataWriter buffer = new BufferedDataWriter(writer.getExportConfig());
-                        try {
-                            writeStartObjectNullType(buffer);
-                            buffer.name(verboseMap[0]);
-                            writeValue(null, e.getKey(), pruner, buffer);
-                            buffer.name(verboseMap[1]);
-                            writeValue(null, e.getValue(), pruner, buffer);
-                            buffer.endObject();
-                            buffer.finished();
-                        } catch (IOException x) {
-                            if (x.getCause() instanceof InvocationTargetException) {
-                                LOGGER.log(Level.WARNING, "skipping export of " + e, x);
-                            }
-                        }
-                        buffer.commit(writer);
-                    }
-                    writer.endArray();
-                } else {// compact form
-                    writeStartObjectNullType(writer);
-                    for (Map.Entry e : ((Map<?,?>) value).entrySet()) {
-                        BufferedDataWriter buffer = new BufferedDataWriter(writer.getExportConfig());
-                        try {
-                            buffer.name(e.getKey().toString());
-                            writeValue(null, e.getValue(), pruner, buffer);
-                            buffer.finished();
-                        } catch (IOException x) {
-                            if (x.getCause() instanceof InvocationTargetException) {
-                                LOGGER.log(Level.WARNING, "skipping export of " + e, x);
-                            }
-                        }
-                        buffer.commit(writer);
-                    }
-                    writer.endObject();
-                }
-                return;
-            }
-            if(value instanceof Date) {
-                writer.valuePrimitive(((Date) value).getTime());
-                return;
-            }
-            if(value instanceof Calendar) {
-                writer.valuePrimitive(((Calendar) value).getTimeInMillis());
-                return;
-            }
-            if(value instanceof Enum) {
-                writer.value(value.toString());
-                return;
-            }
-
-            if (skipIfFail) {
                 writer.startObject();
+                model.writeNestedObjectTo(value, pruner, writer);
                 writer.endObject();
+            } catch (NotExportableException ex) {
+                handleNotExportable(expected, value, pruner, writer, skipIfFail, c);
                 return;
             }
-
-            throw ex;
         }
 
         try {
@@ -305,11 +220,105 @@ public abstract class Property implements Comparable<Property> {
         } catch (AbstractMethodError _) {
             // legacy impl that doesn't understand it
         }
+    }
 
+    private void handleNotExportable(Type expected, Object value, TreePruner pruner, DataWriter writer, boolean skipIfFail, Class c) throws IOException {
+        if(STRING_TYPES.contains(c)) {
+            writer.value(value.toString());
+            return;
+        }
+        if(PRIMITIVE_TYPES.contains(c)) {
+            writer.valuePrimitive(value);
+            return;
+        }
+        Class act = c.getComponentType();
+        if (act !=null) { // array
+            Range r = pruner.getRange();
+            writer.startArray();
+            if (value instanceof Object[]) {
+                // typical case
+                for (Object item : r.apply((Object[]) value)) {
+                    writeBuffered(act, item, pruner, writer);
+                }
+            } else {
+                // more generic case
+                int len = Math.min(r.max, Array.getLength(value));
+                for (int i=r.min; i<len; i++) {
+                    writeBuffered(act, Array.get(value, i), pruner, writer);
+                }
+            }
+            writer.endArray();
+            return;
+        }
+        if(value instanceof Iterable) {
+            writer.startArray();
+            Type expectedItemType = Types.getTypeArgument(expected, 0, null);
+            for (Object item : pruner.getRange().apply((Iterable) value)) {
+                writeBuffered(expectedItemType, item, pruner, writer);
+            }
+            writer.endArray();
+            return;
+        }
+        if(value instanceof Map) {
+            if (verboseMap!=null) {// verbose form
+                writer.startArray();
+                for (Map.Entry e : ((Map<?,?>) value).entrySet()) {
+                    BufferedDataWriter buffer = new BufferedDataWriter(writer.getExportConfig());
+                    try {
+                        writeStartObjectNullType(buffer);
+                        buffer.name(verboseMap[0]);
+                        writeValue(null, e.getKey(), pruner, buffer);
+                        buffer.name(verboseMap[1]);
+                        writeValue(null, e.getValue(), pruner, buffer);
+                        buffer.endObject();
+                        buffer.finished();
+                    } catch (IOException x) {
+                        if (x.getCause() instanceof InvocationTargetException) {
+                            LOGGER.log(Level.WARNING, "skipping export of " + e, x);
+                        }
+                    }
+                    buffer.commit(writer);
+                }
+                writer.endArray();
+            } else {// compact form
+                writeStartObjectNullType(writer);
+                for (Map.Entry e : ((Map<?,?>) value).entrySet()) {
+                    BufferedDataWriter buffer = new BufferedDataWriter(writer.getExportConfig());
+                    try {
+                        buffer.name(e.getKey().toString());
+                        writeValue(null, e.getValue(), pruner, buffer);
+                        buffer.finished();
+                    } catch (IOException x) {
+                        if (x.getCause() instanceof InvocationTargetException) {
+                            LOGGER.log(Level.WARNING, "skipping export of " + e, x);
+                        }
+                    }
+                    buffer.commit(writer);
+                }
+                writer.endObject();
+            }
+            return;
+        }
+        if(value instanceof Date) {
+            writer.valuePrimitive(((Date) value).getTime());
+            return;
+        }
+        if(value instanceof Calendar) {
+            writer.valuePrimitive(((Calendar) value).getTimeInMillis());
+            return;
+        }
+        if(value instanceof Enum) {
+            writer.value(value.toString());
+            return;
+        }
 
-        writer.startObject();
-        model.writeNestedObjectTo(value, pruner, writer);
-        writer.endObject();
+        if (skipIfFail) {
+            writer.startObject();
+            writer.endObject();
+            return;
+        }
+
+        throw new NotExportableException(c);
     }
 
     private static class BufferedDataWriter implements DataWriter {

--- a/core/src/main/java/org/kohsuke/stapler/export/Property.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Property.java
@@ -131,7 +131,7 @@ public abstract class Property implements Comparable<Property> {
         TreePruner child = pruner.accept(object, this);
         if (child==null)        return;
 
-        Object d = writer.getExportConfig().getExportInterceptor().getValue(this,object, writer.getExportConfig());
+        Object d = writer.getExportConfig().getExportInterceptor().getValue(this,object,writer.getExportConfig());
 
         if ((d==null && skipNull) || d == ExportInterceptor.SKIP) { // don't write anything
             return;
@@ -139,15 +139,14 @@ public abstract class Property implements Comparable<Property> {
         if (merge) {
             // merged property will get all its properties written here
             if (d != null) {
-                Model model;
-                try {
-                    model = owner.get(d.getClass(), parent.type, name);
-                } catch (NotExportableException e) {
+                if (d.getClass().getAnnotation(ExportedBean.class) == null) {
                     if(writer.getExportConfig().isSkipIfFail()){
                         return;
+                    } else {
+                        throw new NotExportableException(d.getClass());
                     }
-                    throw e;
                 }
+                Model model = owner.getOrNull(d.getClass(), parent.type, name);
                 model.writeNestedObjectTo(d, new FilteringTreePruner(parent.HAS_PROPERTY_NAME_IN_ANCESTRY,child), writer);
             }
         } else {

--- a/core/src/main/java/org/kohsuke/stapler/export/Property.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Property.java
@@ -198,15 +198,14 @@ public abstract class Property implements Comparable<Property> {
 
         Class c = value.getClass();
 
-        try {
-            writer.type(expected, value.getClass());
-        } catch (AbstractMethodError _) {
-            // legacy impl that doesn't understand it
-        }
-
         if (c.getAnnotation(ExportedBean.class) == null) {
             handleNotExportable(expected, value, pruner, writer, skipIfFail, c);
         } else {
+            try {
+                writer.type(expected, value.getClass());
+            } catch (AbstractMethodError _) {
+                // legacy impl that doesn't understand it
+            }
             try {
                 Model model = owner.getOrNull(c, parent.type, name);
                 if (model == null) {

--- a/core/src/main/java/org/kohsuke/stapler/export/Property.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Property.java
@@ -146,8 +146,6 @@ public abstract class Property implements Comparable<Property> {
                     throw new NotExportableException(objectType);
                 } else if (model != null) {
                     model.writeNestedObjectTo(d, new FilteringTreePruner(parent.HAS_PROPERTY_NAME_IN_ANCESTRY,child), writer);
-                } else {
-                    LOGGER.log(Level.FINE, "Type ");
                 }
             }
         } else {
@@ -199,12 +197,6 @@ public abstract class Property implements Comparable<Property> {
         }
 
         Class c = value.getClass();
-
-        try {
-            writer.type(expected, value.getClass());
-        } catch (AbstractMethodError _) {
-            // legacy impl that doesn't understand it
-        }
 
         Model model = owner.getOrNull(c, parent.type, name);
         if (model == null) {
@@ -305,6 +297,11 @@ public abstract class Property implements Comparable<Property> {
 
             throw new NotExportableException(c);
         } else {
+            try {
+                writer.type(expected, value.getClass());
+            } catch (AbstractMethodError _) {
+                // legacy impl that doesn't understand it
+            }
             writer.startObject();
             model.writeNestedObjectTo(value, pruner, writer);
             writer.endObject();


### PR DESCRIPTION
Removes additional millis per call on large exports by avoiding throwing `NotExportableException` and instead using annotation check to check exportability e.g. `type.getAnnotation(ExportedBean.class)`

See https://github.com/jenkinsci/blueocean-plugin/pull/1323

@reviewbybees #NightTimeCode