### PR TITLE
Use default method for better backward compatibility

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/StaplerResponse.java
+++ b/core/src/main/java/org/kohsuke/stapler/StaplerResponse.java
@@ -195,8 +195,11 @@ public interface StaplerResponse extends HttpServletResponse {
      * in detail; see {@link NamedPathPruner#NamedPathPruner(String)} for details.
      *
      * <p> {@link ExportConfig} is passed by the caller to control serialization behavior
+     * @since 1.251
      */
-    void serveExposedBean(StaplerRequest req, Object exposedBean, ExportConfig exportConfig) throws ServletException,IOException;
+    default void serveExposedBean(StaplerRequest req, Object exposedBean, ExportConfig exportConfig) throws ServletException,IOException {
+        serveExposedBean(req, exposedBean, exportConfig.getFlavor());
+    }
 
     /**
      * Works like {@link #getOutputStream()} but tries to send the response


### PR DESCRIPTION
https://github.com/stapler/stapler/pull/106 added a new method in StaplerResponse, causing backward compatibility issue in a closed source plugin.

As Stapler bumped to Java 8, this change leverages default method to make it more compatible.

@reviewbybees esp. @jglick @vivek @jtnord