### PR TITLE
[stapler#114] Update to Servlet API 3.1.0

### DIFF
--- a/core/maven-example/pom.xml
+++ b/core/maven-example/pom.xml
@@ -13,24 +13,25 @@
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>
       <artifactId>stapler-jsp</artifactId>
-      <version>1.144</version>
+      <!-- TODO update after releasing -->
+      <version>1.253-SNAPSHOT</version>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>jstl</artifactId>
-      <version>1.2</version>
+      <groupId>javax.servlet.jsp.jstl</groupId>
+      <artifactId>javax.servlet.jsp.jstl-api</artifactId>
+      <version>1.2.1</version>
     </dependency>
 
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.3</version>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>jsp-api</artifactId>
-      <version>2.0</version>
+      <groupId>javax.servlet.jsp</groupId>
+      <artifactId>javax.servlet.jsp-api</artifactId>
+      <version>2.3.0</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>
@@ -45,8 +46,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
 
         <configuration>
-          <source>1.5</source>
-          <target>1.5</target>
+          <source>1.7</source>
+          <target>1.7</target>
           <debug>true</debug>
           <showDeprecation>true</showDeprecation>
           <showWarnings>true</showWarnings>
@@ -61,28 +62,20 @@
       </plugin>
 
       <plugin>
-        <groupId>org.mortbay.jetty</groupId>
-        <artifactId>maven-jetty-plugin</artifactId>
-
+        <groupId>org.eclipse.jetty</groupId>
+        <artifactId>jetty-maven-plugin</artifactId>
+        <version>9.4.7.v20170914</version>
         <configuration>
           <scanIntervalSeconds>2</scanIntervalSeconds>
 
-          <connectors>
-            <connector implementation="org.mortbay.jetty.nio.SelectChannelConnector">
-              <port>9090</port>
-              <maxIdleTime>60000</maxIdleTime>
-            </connector>
-          </connectors>
+          <httpConnector>
+            <host>localhost</host>
+            <port>9090</port>
+            <idleTimeout>60000</idleTimeout>
+          </httpConnector>
         </configuration>
       </plugin>
     </plugins>
   </build>
-
-  <repositories>
-    <repository>
-      <id>java.net2</id>
-      <url>http://download.java.net/maven/2/</url>
-    </repository>
-  </repositories>
 
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -32,8 +32,8 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.3</version>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/core/src/main/java/org/kohsuke/stapler/ResponseImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/ResponseImpl.java
@@ -305,7 +305,7 @@ public class ResponseImpl extends HttpServletResponseWrapper implements StaplerR
         // CompressionFilter not available, so do it on our own.
         // see CompressionFilter for why this is not desirable
         setHeader("Content-Encoding","gzip");
-        return recordOutput(new FilterServletOutputStream(new GZIPOutputStream(super.getOutputStream())));
+        return recordOutput(new FilterServletOutputStream(new GZIPOutputStream(super.getOutputStream()), super.getOutputStream()));
     }
 
     public Writer getCompressedWriter(HttpServletRequest req) throws IOException {

--- a/core/src/main/java/org/kohsuke/stapler/StaplerResponseWrapper.java
+++ b/core/src/main/java/org/kohsuke/stapler/StaplerResponseWrapper.java
@@ -15,6 +15,7 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.net.URL;
+import java.util.Collection;
 import java.util.Locale;
 
 /**
@@ -339,5 +340,47 @@ public abstract class StaplerResponseWrapper implements StaplerResponse {
     @Override
     public void setLocale(Locale loc) {
         getWrapped().setLocale(loc);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public int getStatus() {
+        return getWrapped().getStatus();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getHeader(String name) {
+        return getWrapped().getHeader(name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Collection<String> getHeaders(String name) {
+        return getWrapped().getHeaders(name);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Collection<String> getHeaderNames() {
+        return getWrapped().getHeaderNames();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public String getContentType() {
+        return getWrapped().getContentType();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setCharacterEncoding(String charset) {
+        getWrapped().setCharacterEncoding(charset);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void setContentLengthLong(long len) {
+        getWrapped().setContentLengthLong(len);
     }
 }

--- a/core/src/main/java/org/kohsuke/stapler/compression/CompressionServletResponse.java
+++ b/core/src/main/java/org/kohsuke/stapler/compression/CompressionServletResponse.java
@@ -58,7 +58,7 @@ public class CompressionServletResponse extends HttpServletResponseWrapper {
     public void activate() throws IOException {
         if (stream==null) {
             super.setHeader("Content-Encoding", "gzip");
-            stream = new FilterServletOutputStream(new GZIPOutputStream(super.getOutputStream()));
+            stream = new FilterServletOutputStream(new GZIPOutputStream(super.getOutputStream()), stream);
         }
     }
 

--- a/core/src/main/java/org/kohsuke/stapler/compression/FilterServletOutputStream.java
+++ b/core/src/main/java/org/kohsuke/stapler/compression/FilterServletOutputStream.java
@@ -1,6 +1,9 @@
 package org.kohsuke.stapler.compression;
 
 import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
+
+import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 
@@ -11,9 +14,16 @@ import java.io.OutputStream;
  */
 public class FilterServletOutputStream extends ServletOutputStream {
     private final OutputStream out;
-
-    public FilterServletOutputStream(OutputStream out) {
+    private final ServletOutputStream realSream;
+    
+    /**
+     * Constructs a new {@link FilterOutputStream}.
+     * @param out the stream that sits above the realStream, performing some filtering.  This must be eventually delegating eventual writes to {@code realStream}.
+     * @param realStream the actual underlying ServletOutputStream from the container.  Used to check the {@link #isReady()} state and to add {@link WriteListener}s. 
+     */
+    public FilterServletOutputStream(OutputStream out, ServletOutputStream realStream) {
         this.out = out;
+        this.realSream = realStream;
     }
 
     @Override
@@ -39,5 +49,15 @@ public class FilterServletOutputStream extends ServletOutputStream {
     @Override
     public void flush() throws IOException {
         out.flush();
+    }
+
+    @Override
+    public boolean isReady() {
+        return realSream.isReady();
+    }
+
+    @Override
+    public void setWriteListener(WriteListener writeListener) {
+        realSream.setWriteListener(writeListener);
     }
 }

--- a/core/src/test/java/org/kohsuke/stapler/MockRequest.java
+++ b/core/src/test/java/org/kohsuke/stapler/MockRequest.java
@@ -1,10 +1,21 @@
 package org.kohsuke.stapler;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpUpgradeHandler;
+import javax.servlet.http.Part;
 import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.AsyncContext;
+import javax.servlet.DispatcherType;
 import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+
+import java.util.Collection;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
@@ -264,6 +275,121 @@ public class MockRequest implements HttpServletRequest {
     }
 
     public String getRealPath(String path) {
+        // TODO
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public long getContentLengthLong() {
+        // TODO
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getRemotePort() {
+        // TODO
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getLocalName() {
+        // TODO
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getLocalAddr() {
+        // TODO
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getLocalPort() {
+        // TODO
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ServletContext getServletContext() {
+        // TODO
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AsyncContext startAsync() throws IllegalStateException {
+        // TODO
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AsyncContext startAsync(ServletRequest servletRequest, ServletResponse servletResponse)
+            throws IllegalStateException {
+        // TODO
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isAsyncStarted() {
+        // TODO
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isAsyncSupported() {
+        // TODO
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public AsyncContext getAsyncContext() {
+        // TODO
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public DispatcherType getDispatcherType() {
+        // TODO
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String changeSessionId() {
+        // TODO
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean authenticate(HttpServletResponse response) throws IOException, ServletException {
+        // TODO
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void login(String username, String password) throws ServletException {
+        // TODO
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void logout() throws ServletException {
+        // TODO
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Collection<Part> getParts() throws IOException, ServletException {
+        // TODO
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Part getPart(String name) throws IOException, ServletException {
+        // TODO
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T extends HttpUpgradeHandler> T upgrade(Class<T> handlerClass) throws IOException, ServletException {
         // TODO
         throw new UnsupportedOperationException();
     }

--- a/core/src/test/java/org/kohsuke/stapler/MockServletContext.java
+++ b/core/src/test/java/org/kohsuke/stapler/MockServletContext.java
@@ -1,11 +1,21 @@
 package org.kohsuke.stapler;
 
 import javax.servlet.ServletContext;
+import javax.servlet.Filter;
+import javax.servlet.FilterRegistration;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.Servlet;
 import javax.servlet.ServletException;
+import javax.servlet.ServletRegistration;
+import javax.servlet.ServletRegistration.Dynamic;
+import javax.servlet.SessionCookieConfig;
+import javax.servlet.SessionTrackingMode;
+import javax.servlet.descriptor.JspConfigDescriptor;
+
 import java.util.Set;
 import java.util.Enumeration;
+import java.util.EventListener;
+import java.util.Map;
 import java.net.URL;
 import java.net.MalformedURLException;
 import java.io.InputStream;
@@ -103,6 +113,142 @@ public class MockServletContext implements ServletContext {
     }
 
     public String getServletContextName() {
+        return null;
+    }
+
+    @Override
+    public String getContextPath() {
+        return null;
+    }
+
+    @Override
+    public int getEffectiveMajorVersion() {
+        return 0;
+    }
+
+    @Override
+    public int getEffectiveMinorVersion() {
+        return 0;
+    }
+
+    @Override
+    public boolean setInitParameter(String name, String value) {
+        return false;
+    }
+
+    @Override
+    public Dynamic addServlet(String servletName, String className) {
+        return null;
+    }
+
+    @Override
+    public Dynamic addServlet(String servletName, Servlet servlet) {
+        return null;
+    }
+
+    @Override
+    public Dynamic addServlet(String servletName, Class<? extends Servlet> servletClass) {
+        return null;
+    }
+
+    @Override
+    public <T extends Servlet> T createServlet(Class<T> clazz) throws ServletException {
+        return null;
+    }
+
+    @Override
+    public ServletRegistration getServletRegistration(String servletName) {
+        return null;
+    }
+
+    @Override
+    public Map<String, ? extends ServletRegistration> getServletRegistrations() {
+        return null;
+    }
+
+    @Override
+    public javax.servlet.FilterRegistration.Dynamic addFilter(String filterName, String className) {
+        return null;
+    }
+
+    @Override
+    public javax.servlet.FilterRegistration.Dynamic addFilter(String filterName, Filter filter) {
+        return null;
+    }
+
+    @Override
+    public javax.servlet.FilterRegistration.Dynamic addFilter(String filterName, Class<? extends Filter> filterClass) {
+        // TODO Auto-generated method stub
+        return null;
+    }
+
+    @Override
+    public <T extends Filter> T createFilter(Class<T> clazz) throws ServletException {
+        return null;
+    }
+
+    @Override
+    public FilterRegistration getFilterRegistration(String filterName) {
+        return null;
+    }
+
+    @Override
+    public Map<String, ? extends FilterRegistration> getFilterRegistrations() {
+        return null;
+    }
+
+    @Override
+    public SessionCookieConfig getSessionCookieConfig() {
+        return null;
+    }
+
+    @Override
+    public void setSessionTrackingModes(Set<SessionTrackingMode> sessionTrackingModes) {
+    }
+
+    @Override
+    public Set<SessionTrackingMode> getDefaultSessionTrackingModes() {
+        return null;
+    }
+
+    @Override
+    public Set<SessionTrackingMode> getEffectiveSessionTrackingModes() {
+        return null;
+    }
+
+    @Override
+    public void addListener(String className) {
+    }
+
+    @Override
+    public <T extends EventListener> void addListener(T t) {
+    }
+
+    @Override
+    public void addListener(Class<? extends EventListener> listenerClass) {
+    }
+
+    @Override
+    public <T extends EventListener> T createListener(Class<T> clazz) throws ServletException {
+        return null;
+    }
+
+    @Override
+    public JspConfigDescriptor getJspConfigDescriptor() {
+        return null;
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        return null;
+    }
+
+    @Override
+    public void declareRoles(String... roleNames) {
+    }
+
+    @Override
+    public String getVirtualServerName() {
         return null;
     }
 }

--- a/core/src/test/java/org/kohsuke/stapler/RequestImplTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/RequestImplTest.java
@@ -29,6 +29,7 @@ import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.junit.Assert;
 import org.junit.Test;
 
+import javax.servlet.ReadListener;
 import javax.servlet.ServletException;
 import javax.servlet.ServletInputStream;
 import java.io.ByteArrayInputStream;
@@ -82,7 +83,20 @@ public class RequestImplTest {
                     @Override
                     public int read(byte[] b, int off, int len) throws IOException {
                         return is.read(b, off, len);
-                    }                    
+                    }
+                    @Override
+                    public boolean isFinished() {
+                        return is.available() != 0;
+                    }
+                    @Override
+                    public boolean isReady() {
+                        return true;
+                    }
+                    @Override
+                    public void setReadListener(ReadListener readListener) {
+                        // ignored
+                    }
+                    
                 };
             }
         };

--- a/core/src/test/java/org/kohsuke/stapler/ResponseImplTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/ResponseImplTest.java
@@ -3,6 +3,8 @@ package org.kohsuke.stapler;
 import org.kohsuke.stapler.test.AbstractStaplerTest;
 
 import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
+
 import java.io.IOException;
 
 import static javax.servlet.http.HttpServletResponse.*;
@@ -23,6 +25,16 @@ public class ResponseImplTest {
             when(rawResponse.getOutputStream()).thenReturn(new ServletOutputStream() {
                 public void write(int b) throws IOException {
                     throw new AssertionError();
+                }
+
+                @Override
+                public boolean isReady() {
+                    return false;
+                }
+
+                @Override
+                public void setWriteListener(WriteListener writeListener) {
+                    // ignores
                 }
             });
         }

--- a/groovy/pom.xml
+++ b/groovy/pom.xml
@@ -23,8 +23,8 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.3</version>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/jelly/pom.xml
+++ b/jelly/pom.xml
@@ -41,8 +41,8 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.4</version>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
 

--- a/jrebel/pom.xml
+++ b/jrebel/pom.xml
@@ -18,8 +18,8 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.3</version>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/jruby/pom.xml
+++ b/jruby/pom.xml
@@ -38,8 +38,8 @@
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>servlet-api</artifactId>
-      <version>2.3</version>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/jsp/pom.xml
+++ b/jsp/pom.xml
@@ -17,9 +17,15 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>javax.servlet.jsp</groupId>
+      <artifactId>javax.servlet.jsp-api</artifactId>
+      <version>2.3.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>javax.servlet</groupId>
-      <artifactId>jsp-api</artifactId>
-      <version>2.0</version>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.1.0</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Update stapler to use Servlet API 3.1.0 (and other servlet APIs coming from Java EE 7)

Fixes #114 

- [x] manual testing using the [example maven project](https://github.com/stapler/stapler/pull/131/files#diff-b22338ed154eaacfd72f6b6c12442625)
- [x] corresponding PR to Jenkins incorporating the change in a real project (jenkinsci/jenkins#3033)

Code could be cleaned up further with the inclusion of #130 

### Proposed Change Log Entry

* updated API to compiled against Java Servlet API 3.1.0, JSP API 2.3.0 and JSTL API 1.2.1
* This required a API signature change of `org.kohsuke.stapler.compression.FilterServletOutputStream`.
  * It is recommended that users of this class do not upgrade but replace the implementation as this call may be removed in a future version.

@reviewbybees 
