### PR TITLE
Resolve Upper Bound issues, update Groovy

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -44,12 +44,22 @@
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>1.7.0</version>
+      <version>1.8.0</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>1.3.1</version>
+      <version>2.4</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.9</version>
     </dependency>
     <dependency>
       <groupId>org.jvnet.localizer</groupId>

--- a/groovy/pom.xml
+++ b/groovy/pom.xml
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-all</artifactId>
-      <version>1.8.3</version>
+      <version>2.4.11</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/jelly/pom.xml
+++ b/jelly/pom.xml
@@ -28,6 +28,10 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.jenkins-ci.dom4j</groupId>
       <artifactId>dom4j</artifactId>
       <version>1.6.1-jenkins-4</version>

--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
           <dependency>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>extra-enforcer-rules</artifactId>
-            <version>1.0-beta-2</version>
+            <version>1.0-beta-4</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.kohsuke</groupId>
     <artifactId>pom</artifactId>
-    <version>14</version>
+    <version>19</version>
   </parent>
   <groupId>org.kohsuke.stapler</groupId>
   <artifactId>stapler-parent</artifactId>
@@ -122,7 +122,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>1.3.1</version>
+        <version>3.0.0-M1</version>
         <executions>
           <execution>
             <goals>
@@ -140,6 +140,7 @@
                     <string>com.headius.invokebinder.*</string>
                   </ignoreClasses>
                 </enforceBytecodeVersion>
+                <requireUpperBoundDeps />
               </rules>
             </configuration>
           </execution>
@@ -270,6 +271,11 @@
       <artifactId>junit</artifactId>
       <version>4.11</version>
       <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>commons-collections</groupId>
+      <artifactId>commons-collections</artifactId>
+      <version>3.2.2</version>
     </dependency>
   </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
- [x] - Update parent POM
- [x] - Add upper bound enforcement
- [x] - cleanup issues (mostly commons-*)
- [x] - Update Groovy to 2.4.11, so it is the same as the core baseline

All versions are compatible with the Jenkins core.

@reviewbybees @jglick 