### PR TITLE
[JENKINS-34254] Allow customizing RequirePOST error pages

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/interceptor/RequirePOST.java
+++ b/core/src/main/java/org/kohsuke/stapler/interceptor/RequirePOST.java
@@ -49,7 +49,7 @@ public @interface RequirePOST {
         public Object invoke(StaplerRequest request, StaplerResponse response, Object instance, Object[] arguments)
                 throws IllegalAccessException, InvocationTargetException, ServletException {
             if (!request.getMethod().equals("POST")) {
-                for (ErrorCustomizer handler : ServiceLoader.load(ErrorCustomizer.class)) {
+                for (ErrorCustomizer handler : ServiceLoader.load(ErrorCustomizer.class, request.getWebApp().getClassLoader())) {
                     ForwardToView forwardToView = handler.getForwardView();
                     if (forwardToView != null) {
                         throw new InvocationTargetException(forwardToView.with("requestURL", request.getRequestURLWithQueryString().toString()));

--- a/core/src/main/java/org/kohsuke/stapler/interceptor/RequirePOST.java
+++ b/core/src/main/java/org/kohsuke/stapler/interceptor/RequirePOST.java
@@ -14,6 +14,8 @@ import java.util.ServiceLoader;
 
 import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.*;
+
+import javax.annotation.CheckForNull;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
 import org.kohsuke.stapler.HttpResponses;
@@ -37,11 +39,15 @@ public @interface RequirePOST {
 
     /**
      * Allows customizing the error page shown when an annotated method is called with the wrong HTTP method.
-     *
-     * <p>Implementations are looked up using {@link java.util.ServiceLoader}, the first implementation to return a non-null value will be used.</p>
      */
     interface ErrorCustomizer {
-        ForwardToView getForwardView();
+        /**
+         * Return the {@link ForwardToView} showing a custom error page for {@link RequirePOST} annotated methods. This is
+         * typically used to show a form with a "Try again using POST" button.
+         *
+         * <p>Implementations are looked up using {@link java.util.ServiceLoader}, the first implementation to return a non-null value will be used.</p>
+         */
+        @CheckForNull ForwardToView getForwardView();
     }
 
     public static class Processor extends Interceptor {

--- a/core/src/main/java/org/kohsuke/stapler/interceptor/RequirePOST.java
+++ b/core/src/main/java/org/kohsuke/stapler/interceptor/RequirePOST.java
@@ -2,6 +2,8 @@ package org.kohsuke.stapler.interceptor;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+
+import org.kohsuke.stapler.ForwardToView;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
 
@@ -31,11 +33,35 @@ import org.kohsuke.stapler.verb.POST;
 @Target({METHOD,FIELD})
 @InterceptorAnnotation(RequirePOST.Processor.class)
 public @interface RequirePOST {
+
+    /**
+     * Allows customizing the error page shown when an annotated method is called with the wrong HTTP method.
+     */
+    interface ErrorHandler {
+        ForwardToView getForwardView();
+    }
+
     public static class Processor extends Interceptor {
+        private static ErrorHandler handler;
+
+        /**
+         * Register the custom error handler to be used when an annotated method is called with the wrong HTTP method.
+         * @param errorHandler the error handler providing the view to show instead
+         */
+        public static void registerErrorHandler(ErrorHandler errorHandler) {
+            handler = errorHandler;
+        }
+
         @Override
         public Object invoke(StaplerRequest request, StaplerResponse response, Object instance, Object[] arguments)
                 throws IllegalAccessException, InvocationTargetException, ServletException {
             if (!request.getMethod().equals("POST")) {
+                if (handler != null) {
+                    ForwardToView forwardToView = handler.getForwardView();
+                    if (forwardToView != null) {
+                        throw new InvocationTargetException(forwardToView.with("requestURL", request.getRequestURLWithQueryString().toString()));
+                    }
+                }
                 throw new InvocationTargetException(new HttpResponses.HttpResponseException() {
                     public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node) throws IOException, ServletException {
                         rsp.setStatus(HttpServletResponse.SC_METHOD_NOT_ALLOWED);


### PR DESCRIPTION
I'm pretty sure `requestURL` is mostly redundant, but cannot really hurt either to make it easily accessible.

Downstream use: https://github.com/jenkinsci/jenkins/pull/3187
