### PR TITLE
Log when a property is left out of serialised result due to exception

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/export/ExportInterceptor.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/ExportInterceptor.java
@@ -2,6 +2,8 @@ package org.kohsuke.stapler.export;
 
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Allows caller to intercept exporting of properties.
@@ -12,6 +14,9 @@ import java.lang.reflect.InvocationTargetException;
  * @author James Dumay
  */
 public abstract class ExportInterceptor {
+
+    public static final Logger LOGGER = Logger.getLogger(ExportInterceptor.class.getName());
+
     /**
      * Constant to tell if return of {@link ExportInterceptor#getValue(Property, Object, ExportConfig)} should be skipped.
      *
@@ -41,6 +46,7 @@ public abstract class ExportInterceptor {
                 return property.getValue(model);
             } catch (IllegalAccessException | InvocationTargetException e) {
                 if(config.isSkipIfFail()) {
+                    LOGGER.log(Level.WARNING,"Failed to get \"" + property.name + "\" from a " + model.getClass().getName(), e);
                     return SKIP;
                 }
                 throw new IOException("Failed to write " + property.name + ":" + e.getMessage(), e);


### PR DESCRIPTION
Silently dropping properties has been causing issues in front-end code; this will add logging so we'll have something to look for when this happens in the future.

See: https://issues.jenkins-ci.org/browse/JENKINS-48198
