### PR TITLE
[JENKINS-51228] - Create Stapler integration tests for ci.jenkins.io

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,12 +10,16 @@ pipeline {
     stages {
         stage("Build") {
             steps {
-              infra.runMaven(["-Dmaven.test.failure.ignore", "clean", "install", "site"])
+                script {
+                    infra.runMaven(["-Dmaven.test.failure.ignore", "clean", "install", "site"])
+                }
             }
         }
         stage("Integration Tests") {
             steps {
-              essentialsTest(baseDir: "src/test/it")
+                script {
+                    essentialsTest(baseDir: "src/test/it")
+                }
             }
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 pipeline {
     agent {
-      docker 'maven:3.3.9-jdk-8'
+      label 'linux'
     }
 
     environment {
@@ -10,7 +10,7 @@ pipeline {
     stages {
         stage("Build") {
             steps {
-              sh 'mvn -B -Dmaven.test.failure.ignore clean install site'
+              infra.runMaven(["-Dmaven.test.failure.ignore", "clean", "install", "site"])
             }
         }
         stage("Integration Tests") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,11 @@ pipeline {
               sh 'mvn -B -Dmaven.test.failure.ignore clean install site'
             }
         }
+        stage("Integration Tests") {
+            steps {
+              incrementalsTest(baseDir: "src/test/it")
+            }
+        }
     }
 
     post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
         }
         stage("Integration Tests") {
             steps {
-              incrementalsTest(baseDir: "src/test/it")
+              essentialsTest(baseDir: "src/test/it")
             }
         }
     }

--- a/src/test/it/Makefile
+++ b/src/test/it/Makefile
@@ -6,9 +6,7 @@ VERSION = 2.107.3-stapler-it-1.255-SNAPSHOT
 all: clean build
 
 clean:
-	if [ -f "tmp" ]; then
-		rm -rf tmp
-	fi
+	rm -rf tmp
 
 build: tmp/output/target/jenkins-war-${VERSION}.war
 

--- a/src/test/it/Makefile
+++ b/src/test/it/Makefile
@@ -1,0 +1,28 @@
+# Just a Makefile for manual testing
+.PHONY: all
+
+VERSION = 2.107.3-stapler-it-1.255-SNAPSHOT
+
+all: clean build
+
+clean:
+	if [ -f "tmp" ]; then
+		rm -rf tmp
+	fi
+
+build: tmp/output/target/jenkins-war-${VERSION}.war
+
+tmp/output/target/jenkins-war-${VERSION}.war:
+	# TODO: https://github.com/jenkinsci/custom-war-packager/pull/26
+	mvn io.jenkins.tools.custom-war-packager:custom-war-packager-maven-plugin:0.1-alpha-6-20180509.154909-1:build -DconfigFile=essentials.yml -Dversion=${VERSION}
+
+run: tmp/output/target/jenkins-war-${VERSION}.war
+	JENKINS_HOME=work java -jar tmp/output/target/jenkins-war-${VERSION}.war \
+        --httpPort=8080 --prefix=/jenkins
+
+pct: tmp/output/target/jenkins-war-${VERSION}.war
+	docker run --rm -v maven-repo:/root/.m2 -v $(pwd)/out:/pct/out \
+		-v tmp/output/target/jenkins-war-${VERSION}.war:/pct/jenkins.war:ro \
+		-e ARTIFACT_ID=pipeline-maven \
+		-e INSTALL_BUNDLED_SNAPSHOTS=true \
+		jenkins/pct

--- a/src/test/it/Makefile
+++ b/src/test/it/Makefile
@@ -19,8 +19,8 @@ run: tmp/output/target/jenkins-war-${VERSION}.war
         --httpPort=8080 --prefix=/jenkins
 
 pct: tmp/output/target/jenkins-war-${VERSION}.war
-	docker run --rm -v maven-repo:/root/.m2 -v $(pwd)/out:/pct/out \
-		-v tmp/output/target/jenkins-war-${VERSION}.war:/pct/jenkins.war:ro \
+	docker run --rm -v maven-repo:/root/.m2 -v $(shell pwd)/out:/pct/out \
+		-v $(shell pwd)/tmp/output/target/jenkins-war-${VERSION}.war:/pct/jenkins.war:ro \
 		-e ARTIFACT_ID=pipeline-maven \
 		-e INSTALL_BUNDLED_SNAPSHOTS=true \
 		jenkins/pct

--- a/src/test/it/essentials.yml
+++ b/src/test/it/essentials.yml
@@ -1,0 +1,78 @@
+---
+packaging:
+  # We cannot use BOM here, because BOM does not support build by relative path
+  configFile: "packager-config.yml"
+  archiveArtifacts: true
+  config:
+    bundle:
+      groupId: "io.jenkins-ci.main"
+      artifactId: "jenkins-war"
+      vendor: "Jenkins project"
+      title: "Jenkins WAR - Stapler Integration Tests"
+      description: "Bundles stapler "
+    war:
+      groupId: "org.jenkins-ci.main"
+      artifactId: "jenkins-war"
+      source:
+        version: 2.107.3
+    plugins:
+      # Includes stapler-adjunct-jquery, we may want to test compatibility
+      - groupId: "org.jenkins-ci.plugins"
+        artifactId: "jquery"
+        source:
+          version: "1.12.4-0"
+      # Includes stapler-groovy, we may want to test compatibility
+      - groupId: "org.jenkins-ci.plugins.icon-shim"
+        artifactId: "icon-shim"
+        source:
+          version: "2.0.3"
+      # Includes Stapler directly
+      #TODO: Why?
+      - groupId: "org.jenkins-ci.plugins"
+        artifactId: "pipeline-maven"
+        source:
+          version: "3.5.5"
+      # Upper bounds and JENKINS-51224
+      - groupId: "org.jenkins-ci.plugins"
+        artifactId: "junit"
+        source:
+          version: "1.20"
+    libPatches:
+      - groupId: "org.kohsuke.stapler"
+        artifactId: "stapler"
+        source:
+          dir: ../../..
+      - groupId: "org.kohsuke.stapler"
+        artifactId: "stapler-groovy"
+        source:
+          dir: ../../..
+      - groupId: "org.kohsuke.stapler"
+        artifactId: "stapler-jelly"
+        source:
+          dir: ../../..
+      - groupId: "org.kohsuke.stapler"
+        artifactId: "stapler-jrebel"
+        source:
+          dir: ../../..
+ath:
+  useLocalSnapshots: false
+  athImage: "local"
+  tests:
+    - "plugins.WorkflowPluginTest"
+    - "plugins.StageViewTest"
+    - "core.SlaveTest"
+    - "core.PluginManagerTest"
+    - "core.ViewTest"
+  categories:
+    - "org.jenkinsci.test.acceptance.junit.SmokeTest"
+pct:
+  useLocalSnapshots: false
+  jth:
+    version: 2.38
+    passCustomJenkinsWAR: true
+  plugins:
+    - "jquery"
+    - "icon-shim"
+    - "pipeline-maven"
+    - "pipeline-stage-view"
+

--- a/src/test/it/essentials.yml
+++ b/src/test/it/essentials.yml
@@ -1,6 +1,5 @@
 ---
 packaging:
-  # We cannot use BOM here, because BOM does not support build by relative path
   configFile: "packager-config.yml"
   archiveArtifacts: true
   config:


### PR DESCRIPTION
Currently Jenkins is not tested during the build of Stapler, so we miss issues and handle them only when changes are proposed to the Jenkins core and integrated into Weekly. I propose to introduce some integration testing using the `essentialsTest()` framework we recently created

https://issues.jenkins-ci.org/browse/JENKINS-51228

@reviewbybees @jglick @raul-arabaolaza @daniel-beck  
