### PR TITLE
promote field injection with declarative constraints

### DIFF
--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -12,4 +12,12 @@
   <artifactId>annotations</artifactId>
 
 
+  <dependencies>
+    <dependency>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>access-modifier-annotation</artifactId>
+      <version>1.13</version>
+    </dependency>
+  </dependencies>
+
 </project>

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>stapler-parent</artifactId>
+    <groupId>org.kohsuke.stapler</groupId>
+    <version>1.255-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>annotations</artifactId>
+
+
+</project>

--- a/annotations/src/main/java/org/kohsuke/stapler/DataBound.java
+++ b/annotations/src/main/java/org/kohsuke/stapler/DataBound.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2018, Nicolas De Loof
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler;
+
+import javax.annotation.PostConstruct;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Designates a field used to data-bind JSON values into objects.
+ *
+ * <p>
+ * To create a method to be called after all the injections are complete, annotate a method
+ * with {@link PostConstruct}. This typically can be used to accept legacy JSON using deprecated
+ * keys and process data conversion.
+ *
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+@Retention(RUNTIME)
+@Target({FIELD})
+@Documented
+public @interface DataBound {
+
+    /**
+     * Mark an attribute as required for data-binding. If not provided in JSON payload instanciation will fail.
+     */
+    boolean required() default false;
+
+}

--- a/annotations/src/main/java/org/kohsuke/stapler/DataBound.java
+++ b/annotations/src/main/java/org/kohsuke/stapler/DataBound.java
@@ -29,7 +29,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.FIELD;
-import static java.lang.annotation.RetentionPolicy.CLASS;
+import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
@@ -43,7 +43,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 @Retention(RUNTIME)
-@Target({FIELD})
+@Target({FIELD, METHOD})
 @Documented
 public @interface DataBound {
 

--- a/annotations/src/main/java/org/kohsuke/stapler/Required.java
+++ b/annotations/src/main/java/org/kohsuke/stapler/Required.java
@@ -23,9 +23,6 @@
 
 package org.kohsuke.stapler;
 
-import org.kohsuke.accmod.Restricted;
-import org.kohsuke.accmod.restrictions.NoExternalUse;
-
 import javax.annotation.PostConstruct;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -33,31 +30,23 @@ import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.TYPE;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Designates a field used to data-bind JSON values into objects.
- *
- * <p>
- * a DataBound field, method or class is automatically marked as ${@link Restricted} as
- * making it public is only required to let Stapler manage the class, but there's no legitimate
- * reason for it to be used in another context.
- *
- * <p>
- * When used on a type, implies all attributes are considered to be <code>@DataBound</code>.
- *
- * <p>
- * To create a method to be called after all the injections are complete, annotate a method
- * with {@link PostConstruct}. This typically can be used to accept legacy JSON using deprecated
- * keys and process data conversion.
- *
+ * Designates a {@link DataBound} field to require trimming before value being set.
+ **
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 @Retention(RUNTIME)
-@Target({FIELD, METHOD, TYPE})
+@Target({FIELD, METHOD})
 @Documented
-@Restricted(NoExternalUse.class)
-public @interface DataBound {
+public @interface Trim {
+
+    enum Type { TO_EMPTY, TO_NULL }
+
+    /**
+     * Mark an attribute as required for data-binding. If not provided in JSON payload instanciation will fail.
+     */
+    Type value() default Type.TO_NULL;
 
 }

--- a/annotations/src/main/java/org/kohsuke/stapler/Required.java
+++ b/annotations/src/main/java/org/kohsuke/stapler/Required.java
@@ -23,7 +23,6 @@
 
 package org.kohsuke.stapler;
 
-import javax.annotation.PostConstruct;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
@@ -33,20 +32,12 @@ import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Designates a {@link DataBound} field to require trimming before value being set.
+ * Designates a {@link DataBound} field is required: if not provided in JSON payload instanciation will fail.
  **
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 @Retention(RUNTIME)
 @Target({FIELD, METHOD})
 @Documented
-public @interface Trim {
-
-    enum Type { TO_EMPTY, TO_NULL }
-
-    /**
-     * Mark an attribute as required for data-binding. If not provided in JSON payload instanciation will fail.
-     */
-    Type value() default Type.TO_NULL;
-
+public @interface Required {
 }

--- a/annotations/src/main/java/org/kohsuke/stapler/Trim.java
+++ b/annotations/src/main/java/org/kohsuke/stapler/Trim.java
@@ -29,6 +29,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
@@ -37,7 +38,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 @Retention(RUNTIME)
-@Target({FIELD})
+@Target({FIELD, METHOD})
 @Documented
 public @interface Trim {
 

--- a/annotations/src/main/java/org/kohsuke/stapler/Trim.java
+++ b/annotations/src/main/java/org/kohsuke/stapler/Trim.java
@@ -30,15 +30,16 @@ import java.lang.annotation.Target;
 
 import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.ElementType.PARAMETER;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Designates a {@link DataBound} field to require trimming before value being set.
+ * Designates a {@link DataBound} field or parameter which will be automatically trimmed before value is set.
  **
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 @Retention(RUNTIME)
-@Target({FIELD, METHOD})
+@Target({FIELD, PARAMETER})
 @Documented
 public @interface Trim {
 

--- a/annotations/src/main/java/org/kohsuke/stapler/Trim.java
+++ b/annotations/src/main/java/org/kohsuke/stapler/Trim.java
@@ -23,9 +23,6 @@
 
 package org.kohsuke.stapler;
 
-import net.sf.json.JSONObject;
-import org.apache.commons.lang.StringUtils;
-
 import javax.annotation.PostConstruct;
 import java.lang.annotation.Documented;
 import java.lang.annotation.Retention;
@@ -35,49 +32,20 @@ import static java.lang.annotation.ElementType.FIELD;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Designates a field used to databind JSON values into objects in methods like
- * {@link StaplerRequest#bindJSON(Class, JSONObject)} and
- * {@link StaplerRequest#bindParameters(Class, String)}.
- *
- * <p>
- * Stapler will first invoke {@link DataBoundConstructor}-annotated constructor, and if there's any
- * remaining properties in JSON, it'll try to find a matching {@link DataBound}-annotated fields.
- *
- * <p>
- * To create a method to be called after all the setter injections are complete, annotate a method
- * with {@link PostConstruct}.
- *
+ * Designates a {@link DataBound} field to require trimming before value being set.
+ **
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 @Retention(RUNTIME)
 @Target({FIELD})
 @Documented
-public @interface DataBound {
+public @interface Trim {
 
-    enum Trim {
-        NONE {
-            @Override
-            public Object apply(Object val) {
-                return val;
-            }
-        }, TONULL {
-            @Override
-            public Object apply(Object val) {
-                return StringUtils.trimToNull((String) val);
-            }
-        }, TOEMPTY {
-            @Override
-            public Object apply(Object val) {
-                return StringUtils.trimToEmpty((String) val);
-            }
-        };
-
-        public abstract Object apply(Object val);
-
-    }
+    enum Type { TO_EMPTY, TO_NULL }
 
     /**
-     * Define pre-processing of string-based values before they get injected and validated.
+     * Mark an attribute as required for data-binding. If not provided in JSON payload instanciation will fail.
      */
-    Trim trim() default Trim.NONE;
+    Type value() default Type.TO_NULL;
+
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -26,6 +26,11 @@
   </build>
   <dependencies>
     <dependency>
+      <groupId>${groupId}</groupId>
+      <artifactId>annotations</artifactId>
+      <version>${version}</version>
+    </dependency>
+    <dependency>
       <groupId>javax.annotation</groupId>
       <artifactId>javax.annotation-api</artifactId>
       <version>1.2</version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -154,6 +154,12 @@
       <version>1.1.3</version>
     </dependency>
     <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <version>6.0.10.Final</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpmime</artifactId>
       <version>4.5</version>

--- a/core/src/main/java/org/kohsuke/stapler/ClassDescriptor.java
+++ b/core/src/main/java/org/kohsuke/stapler/ClassDescriptor.java
@@ -261,6 +261,15 @@ public final class ClassDescriptor {
             }
         }
 
+        if (dbc==null) {
+            for (Constructor<?> c : ctrs) {
+                if (c.getParameterCount() == 0) {
+                    // we can use default constructor in combination with @DataBoundSetters
+                    return new String[0];
+                }
+            }
+        }
+
         if (dbc==null)
             throw new NoStaplerConstructorException("There's no @DataBoundConstructor on any constructor of " + clazz);
 

--- a/core/src/main/java/org/kohsuke/stapler/ConstraintsValidationException.java
+++ b/core/src/main/java/org/kohsuke/stapler/ConstraintsValidationException.java
@@ -1,0 +1,49 @@
+/*
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler;
+
+import javax.validation.ConstraintViolation;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class ConstraintsValidationException extends IllegalArgumentException {
+
+    private Set<ConstraintViolation> violations;
+
+    public ConstraintsValidationException(Set<ConstraintViolation> violations) {
+        super();
+        this.violations = violations;
+    }
+
+    @Override
+    public String getMessage() {
+        return violations.stream().map(v -> v.getPropertyPath() + ": " + v.getMessage()).collect(Collectors.joining(", "));
+    }
+
+    public Set<ConstraintViolation> getViolations() {
+        return violations;
+    }
+}

--- a/core/src/main/java/org/kohsuke/stapler/ConstraintsValidationException.java
+++ b/core/src/main/java/org/kohsuke/stapler/ConstraintsValidationException.java
@@ -24,6 +24,7 @@
 package org.kohsuke.stapler;
 
 import javax.validation.ConstraintViolation;
+import javax.validation.Path;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -46,5 +47,14 @@ public class ConstraintsValidationException extends IllegalArgumentException {
 
     public Set<ConstraintViolation> getViolations() {
         return violations;
+    }
+
+    public Set<ConstraintViolation> getViolations(String path) {
+        return violations.stream().filter(v -> v.getPropertyPath().toString().equals(path))
+                .collect(Collectors.toSet());
+    }
+
+    public Set<String> getPaths() {
+        return violations.stream().map(ConstraintViolation::getPropertyPath).map(Path::toString).collect(Collectors.toSet());
     }
 }

--- a/core/src/main/java/org/kohsuke/stapler/ConstraintsValidationException.java
+++ b/core/src/main/java/org/kohsuke/stapler/ConstraintsValidationException.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2018, Nicolas De Loof
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without modification, are permitted provided

--- a/core/src/main/java/org/kohsuke/stapler/DataBound.java
+++ b/core/src/main/java/org/kohsuke/stapler/DataBound.java
@@ -1,0 +1,32 @@
+package org.kohsuke.stapler;
+
+import net.sf.json.JSONObject;
+
+import javax.annotation.PostConstruct;
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Designates a field used to databind JSON values into objects in methods like
+ * {@link StaplerRequest#bindJSON(Class, JSONObject)} and
+ * {@link StaplerRequest#bindParameters(Class, String)}.
+ *
+ * <p>
+ * Stapler will first invoke {@link DataBoundConstructor}-annotated constructor, and if there's any
+ * remaining properties in JSON, it'll try to find a matching {@link DataBound}-annotated fields.
+ *
+ * <p>
+ * To create a method to be called after all the setter injections are complete, annotate a method
+ * with {@link PostConstruct}.
+ *
+ * @author Kohsuke Kawaguchi
+ */
+@Retention(RUNTIME)
+@Target({FIELD})
+@Documented
+public @interface DataBound {
+}

--- a/core/src/main/java/org/kohsuke/stapler/DataBound.java
+++ b/core/src/main/java/org/kohsuke/stapler/DataBound.java
@@ -1,6 +1,7 @@
 package org.kohsuke.stapler;
 
 import net.sf.json.JSONObject;
+import org.apache.commons.lang.StringUtils;
 
 import javax.annotation.PostConstruct;
 import java.lang.annotation.Documented;
@@ -29,4 +30,31 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
 @Target({FIELD})
 @Documented
 public @interface DataBound {
+
+    enum Trim {
+        NONE {
+            @Override
+            public Object apply(Object val) {
+                return val;
+            }
+        }, TONULL {
+            @Override
+            public Object apply(Object val) {
+                return StringUtils.trimToNull((String) val);
+            }
+        }, TOEMPTY {
+            @Override
+            public Object apply(Object val) {
+                return StringUtils.trimToEmpty((String) val);
+            }
+        };
+
+        public abstract Object apply(Object val);
+
+    }
+
+    /**
+     * Define pre-processing of string-based values before they get injected and validated.
+     */
+    Trim trim() default Trim.NONE;
 }

--- a/core/src/main/java/org/kohsuke/stapler/DataBound.java
+++ b/core/src/main/java/org/kohsuke/stapler/DataBound.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2018, Nicolas De Loof
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package org.kohsuke.stapler;
 
 import net.sf.json.JSONObject;
@@ -24,7 +47,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * To create a method to be called after all the setter injections are complete, annotate a method
  * with {@link PostConstruct}.
  *
- * @author Kohsuke Kawaguchi
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
 @Retention(RUNTIME)
 @Target({FIELD})

--- a/core/src/main/java/org/kohsuke/stapler/Function.java
+++ b/core/src/main/java/org/kohsuke/stapler/Function.java
@@ -118,7 +118,7 @@ public abstract class Function {
             if (getReturnType() != void.class)
                 renderResponse(req, rsp, node, r);
             return true;
-        } catch (CancelRequestHandlingException _) {
+        } catch (CancelRequestHandlingException ex) {
             return false;
         } catch (InvocationTargetException e) {
             // exception as an HttpResponse

--- a/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
@@ -413,7 +413,7 @@ public class RequestImpl extends HttpServletRequestWrapper implements StaplerReq
             // use the designated constructor for databinding
             for( int i=0; i<len; i++ )
                 r.add(bindParameters(type,prefix,i));
-        } catch (NoStaplerConstructorException _) {
+        } catch (NoStaplerConstructorException ex) {
             // no designated data binding constructor. use reflection
             try {
                 for( int i=0; i<len; i++ ) {

--- a/core/src/main/java/org/kohsuke/stapler/export/TypeUtil.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/TypeUtil.java
@@ -82,26 +82,26 @@ public class TypeUtil {
      * Implements the logic for {@link #erasure(Type)}.
      */
     private static final TypeVisitor<Class,Void> eraser = new TypeVisitor<Class,Void>() {
-        public Class onClass(Class c,Void _) {
+        public Class onClass(Class c,Void v) {
             return c;
         }
 
-        public Class onParameterizedType(ParameterizedType p,Void _) {
+        public Class onParameterizedType(ParameterizedType p,Void v) {
             // TODO: why getRawType returns Type? not Class?
             return visit(p.getRawType(),null);
         }
 
-        public Class onGenericArray(GenericArrayType g,Void _) {
+        public Class onGenericArray(GenericArrayType g,Void v) {
             return Array.newInstance(
                 visit(g.getGenericComponentType(),null),
                 0 ).getClass();
         }
 
-        public Class onVariable(TypeVariable v,Void _) {
-            return visit(v.getBounds()[0],null);
+        public Class onVariable(TypeVariable t,Void v) {
+            return visit(t.getBounds()[0],null);
         }
 
-        public Class onWildcard(WildcardType w,Void _) {
+        public Class onWildcard(WildcardType w,Void v) {
             return visit(w.getUpperBounds()[0],null);
         }
     };

--- a/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
@@ -5,6 +5,12 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
 import javax.annotation.PostConstruct;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.Size;
 import java.lang.reflect.Type;
 import java.net.Proxy;
 import java.util.ArrayList;
@@ -328,6 +334,40 @@ public class DataBindingTest extends TestCase {
         r.assertValues();
         assertEquals(10,r.post);
     }
+
+    public static class BeanValidation {
+
+        @DataBound
+        @Positive
+        private int x;
+
+        @DataBound
+        @NotBlank
+        private String y;
+
+        @DataBound
+        private String z;
+
+        void assertValues() {
+            assertEquals(1,x);
+            assertEquals("2",y);
+            assertEquals("3",z);
+        }
+    }
+
+    public void testFieldInjectionWithValidation() {
+        BeanValidation r = bind("{x:1,y:'2',z:'3'} }",BeanValidation.class);
+        r.assertValues();
+
+        try {
+            bind("{x:0,y:' ',z:'foo'} }", BeanValidation.class);
+            fail("validation was expected to fail.");
+        } catch (IllegalArgumentException e) {
+            System.out.println(e.getCause());
+        }
+
+    }
+
 
     public void testInterceptor1() {
         String r = bind("{x:1}", String.class, new BindInterceptor() {

--- a/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
@@ -339,8 +339,12 @@ public class DataBindingTest extends TestCase {
         @DataBound @NotBlank
         private String y;
 
-        @DataBound @Trim
         private String z;
+
+        @DataBound @Trim
+        public void setZ(String z) {
+            this.z = z;
+        }
 
         void assertValues() {
             assertEquals(1,x);

--- a/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
@@ -5,12 +5,8 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
 import javax.annotation.PostConstruct;
-import javax.validation.constraints.Min;
 import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotEmpty;
-import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Positive;
-import javax.validation.constraints.Size;
 import java.lang.reflect.Type;
 import java.net.Proxy;
 import java.util.ArrayList;
@@ -335,7 +331,7 @@ public class DataBindingTest extends TestCase {
         assertEquals(10,r.post);
     }
 
-    public static class BeanValidation {
+    public static class DataBoundBean {
 
         @DataBound
         @Positive
@@ -345,29 +341,30 @@ public class DataBindingTest extends TestCase {
         @NotBlank
         private String y;
 
-        @DataBound
+        @DataBound(trim = DataBound.Trim.TONULL)
         private String z;
 
         void assertValues() {
             assertEquals(1,x);
             assertEquals("2",y);
-            assertEquals("3",z);
+            assertEquals(null,z);
         }
     }
 
     public void testFieldInjectionWithValidation() {
-        BeanValidation r = bind("{x:1,y:'2',z:'3'} }",BeanValidation.class);
-        r.assertValues();
+        bind("{x:1,y:'2'} }",DataBoundBean.class)
+          .assertValues();
+
+        bind("{x:1,y:'2', z:'   '} }",DataBoundBean.class)
+          .assertValues();
 
         try {
-            bind("{x:0,y:' ',z:'foo'} }", BeanValidation.class);
+            bind("{x:0,y:' '} }", DataBoundBean.class);
             fail("validation was expected to fail.");
         } catch (IllegalArgumentException e) {
             System.out.println(e.getCause());
         }
-
     }
-
 
     public void testInterceptor1() {
         String r = bind("{x:1}", String.class, new BindInterceptor() {

--- a/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
@@ -312,9 +312,6 @@ public class DataBindingTest extends TestCase {
     }
 
     public static class Point3Derived extends Point3 {
-        @DataBoundConstructor
-        public Point3Derived() {
-        }
 
         @PostConstruct
         private void post1() {
@@ -372,8 +369,6 @@ public class DataBindingTest extends TestCase {
 
     public static class AsymmetricProperty {
         private final List<Integer> items = new ArrayList<Integer>();
-        @DataBoundConstructor
-        public AsymmetricProperty() {}
 
         public List<Integer> getItems() {
             return items;
@@ -395,8 +390,6 @@ public class DataBindingTest extends TestCase {
     }
 
     public static class DerivedProperty extends AsymmetricProperty {
-        @DataBoundConstructor
-        public DerivedProperty() {}
 
         @Override
         public void setItems(Collection<Integer> v) {

--- a/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
@@ -297,12 +297,16 @@ public class DataBindingTest extends TestCase {
         @DataBoundSetter
         private int x,y,z;
 
+        @DataBound
+        private int w;
+
         int post=1;
 
         public void assertValues() {
             assertEquals(1,x);
             assertEquals(2,y);
             assertEquals(3,z);
+            assertEquals(4,w);
         }
 
         @PostConstruct
@@ -320,7 +324,7 @@ public class DataBindingTest extends TestCase {
     }
 
     public void testFieldInjection() {
-        Point3Derived r = bind("{x:1,y:2,z:3} }",Point3Derived.class);
+        Point3Derived r = bind("{x:1,y:2,z:3,w:4} }",Point3Derived.class);
         r.assertValues();
         assertEquals(10,r.post);
     }

--- a/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
@@ -3,6 +3,7 @@ package org.kohsuke.stapler;
 import junit.framework.TestCase;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
+import org.kohsuke.accmod.Restricted;
 
 import javax.annotation.PostConstruct;
 import javax.validation.constraints.NotBlank;
@@ -331,9 +332,9 @@ public class DataBindingTest extends TestCase {
         assertEquals(10,r.post);
     }
 
-    public static class DataBoundBean {
+    public static class ValidatedBean {
 
-        @DataBound(required = true) @Positive
+        @DataBound @Required @Positive
         private int x;
 
         @DataBound @NotBlank
@@ -354,25 +355,51 @@ public class DataBindingTest extends TestCase {
     }
 
     public void testFieldInjectionWithValidation() {
-        bind("{x:1,y:'2'}",DataBoundBean.class)
+        bind("{x:1,y:'2'}",ValidatedBean.class)
           .assertValues();
 
-        bind("{x:1,y:'2', z:'   '}",DataBoundBean.class)
+        bind("{x:1,y:'2', z:'   '}",ValidatedBean.class)
           .assertValues();
 
         try {
-            bind("{x:0,y:' '}", DataBoundBean.class);
+            bind("{x:0,y:' '}", ValidatedBean.class);
             fail("validation was expected to fail.");
         } catch (IllegalArgumentException e) {
             System.out.println(e.getCause());
         }
 
         try {
-            bind("{y:'2'}", DataBoundBean.class);
+            bind("{y:'2'}", ValidatedBean.class);
             fail("validation was expected to fail.");
         } catch (IllegalArgumentException e) {
             System.out.println(e.getCause());
         }
+    }
+
+    @DataBound
+    public static class DataBoundBean {
+
+        @Required @Positive
+        private int x;
+
+        @NotBlank
+        private String y;
+
+        @Trim
+        private String z;
+
+        void assertValues() {
+            assertEquals(1,x);
+            assertEquals("2",y);
+            assertEquals(null,z);
+        }
+    }
+
+    public void testDataBoundBean() {
+        bind("{x:1,y:'2', z:'   '}", DataBoundBean.class)
+            .assertValues();
+
+        DataBoundBean.class.isAnnotationPresent(Restricted.class);
     }
 
     public void testInterceptor1() {

--- a/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
@@ -333,15 +333,13 @@ public class DataBindingTest extends TestCase {
 
     public static class DataBoundBean {
 
-        @DataBound
-        @Positive
+        @DataBound(required = true) @Positive
         private int x;
 
-        @DataBound
-        @NotBlank
+        @DataBound @NotBlank
         private String y;
 
-        @DataBound(trim = DataBound.Trim.TONULL)
+        @DataBound @Trim
         private String z;
 
         void assertValues() {
@@ -352,14 +350,21 @@ public class DataBindingTest extends TestCase {
     }
 
     public void testFieldInjectionWithValidation() {
-        bind("{x:1,y:'2'} }",DataBoundBean.class)
+        bind("{x:1,y:'2'}",DataBoundBean.class)
           .assertValues();
 
-        bind("{x:1,y:'2', z:'   '} }",DataBoundBean.class)
+        bind("{x:1,y:'2', z:'   '}",DataBoundBean.class)
           .assertValues();
 
         try {
-            bind("{x:0,y:' '} }", DataBoundBean.class);
+            bind("{x:0,y:' '}", DataBoundBean.class);
+            fail("validation was expected to fail.");
+        } catch (IllegalArgumentException e) {
+            System.out.println(e.getCause());
+        }
+
+        try {
+            bind("{y:'2'}", DataBoundBean.class);
             fail("validation was expected to fail.");
         } catch (IllegalArgumentException e) {
             System.out.println(e.getCause());

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
   <description>Stapler HTTP request handling engine</description>
   
   <modules>
+    <module>annotations</module>
     <module>core</module>
     <module>jsp</module>
     <module>jelly</module>


### PR DESCRIPTION
# Work in progress, do not merge

Plugin developers use to rely on `@DataBoundConstructor`s to get raw data and proceed validation, trim, null check and all that sort of things.

I propose we rely on a declarative approach to define data-binding constraints based on bean validation (jsr 303) annotations. This allows to detect those constraints by reflexion (for sample, to be used by Configuration-as-Code), and as such could also be used to improve the jelly tags library to offer client-side validation.

This is reference implementation for JPE-[TBD]