### PR TITLE
Allow optional st:include with class attribute

### DIFF
--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/IncludeTag.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/IncludeTag.java
@@ -113,6 +113,10 @@ public class IncludeTag extends TagSupport {
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
+            if(optional) {
+                invokeBody(output);
+                return;
+            }
             throw new JellyTagException("Error loading '"+page+"' for "+c.klass,e);
         }
 


### PR DESCRIPTION
When writing https://github.com/jenkinsci/login-theme-plugin I stumbled over the following not working (exception thrown) if the specified class did not have the specified page:

    <st:include class="jenkins.model.DefaultSimplePageDecorator" page="simple-footer.jelly" optional="true" />

Tested and confirmed working interactively. Unsure where I'd put tests. Thoughts?