### PR TITLE
add bean-validation, @Trim and @DefaultValue annotations

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -154,9 +154,15 @@
       <version>1.1.3</version>
     </dependency>
     <dependency>
-      <groupId>org.hibernate</groupId>
+      <groupId>javax.validation</groupId>
+      <artifactId>validation-api</artifactId>
+      <version>2.0.1.Final</version>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate.validator</groupId>
       <artifactId>hibernate-validator</artifactId>
-      <version>6.0.10.Final</version>
+      <version>6.0.13.Final</version>
+      <scope>runtime</scope>
     </dependency>
 
     <dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -154,6 +154,12 @@
       <version>1.1.3</version>
     </dependency>
     <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+      <version>6.0.10.Final</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpmime</artifactId>
       <version>4.5</version>

--- a/core/src/main/java/org/kohsuke/stapler/ClassDescriptor.java
+++ b/core/src/main/java/org/kohsuke/stapler/ClassDescriptor.java
@@ -261,6 +261,15 @@ public final class ClassDescriptor {
             }
         }
 
+        if (dbc==null) {
+            for (Constructor<?> c : ctrs) {
+                if (c.getParameterCount() == 0) {
+                    // we can use default constructor in combination with @DataBoundSetters
+                    return new String[0];
+                }
+            }
+        }
+
         if (dbc==null)
             throw new NoStaplerConstructorException("There's no @DataBoundConstructor on any constructor of " + clazz);
 

--- a/core/src/main/java/org/kohsuke/stapler/ConstraintsValidationException.java
+++ b/core/src/main/java/org/kohsuke/stapler/ConstraintsValidationException.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2018, Nicolas De Loof
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package org.kohsuke.stapler;
+
+import javax.validation.ConstraintViolation;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class ConstraintsValidationException extends IllegalArgumentException {
+
+    private Set<ConstraintViolation> violations;
+
+    public ConstraintsValidationException(Set<ConstraintViolation> violations) {
+        super();
+        this.violations = violations;
+    }
+
+    @Override
+    public String getMessage() {
+        return violations.stream().map(v -> v.getPropertyPath() + ": " + v.getMessage()).collect(Collectors.joining(", "));
+    }
+
+    public Set<ConstraintViolation> getViolations() {
+        return violations;
+    }
+}

--- a/core/src/main/java/org/kohsuke/stapler/DefaultValue.java
+++ b/core/src/main/java/org/kohsuke/stapler/DefaultValue.java
@@ -1,0 +1,19 @@
+package org.kohsuke.stapler;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Indicate value to be used when databound payload is missing property <em>or</em> provided value is null
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER})
+public @interface DefaultValue {
+
+    String value();
+}

--- a/core/src/main/java/org/kohsuke/stapler/Function.java
+++ b/core/src/main/java/org/kohsuke/stapler/Function.java
@@ -118,7 +118,7 @@ public abstract class Function {
             if (getReturnType() != void.class)
                 renderResponse(req, rsp, node, r);
             return true;
-        } catch (CancelRequestHandlingException _) {
+        } catch (CancelRequestHandlingException ex) {
             return false;
         } catch (InvocationTargetException e) {
             // exception as an HttpResponse

--- a/core/src/main/java/org/kohsuke/stapler/PostProcessor.java
+++ b/core/src/main/java/org/kohsuke/stapler/PostProcessor.java
@@ -1,0 +1,7 @@
+package org.kohsuke.stapler;
+
+/**
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+public class PostProcessor {
+}

--- a/core/src/main/java/org/kohsuke/stapler/Replaceable.java
+++ b/core/src/main/java/org/kohsuke/stapler/Replaceable.java
@@ -1,0 +1,21 @@
+package org.kohsuke.stapler;
+
+import java.io.IOException;
+
+/**
+ * A data structure that support replacing it's content.
+ * Primarily used to support hudson.util.PersistedList, which can be exposed as public final fields, but still
+ * (re)configured by stapler on structured form submission.
+ *
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ * @since TODO
+ */
+public interface Replaceable<T> {
+
+    /**
+     * Replace the data content of current object with new value.
+     * @param newValue
+     * @throws IOException
+     */
+    void replaceBy(T newValue) throws IOException;
+}

--- a/core/src/main/java/org/kohsuke/stapler/Replaceable.java
+++ b/core/src/main/java/org/kohsuke/stapler/Replaceable.java
@@ -3,7 +3,7 @@ package org.kohsuke.stapler;
 import java.io.IOException;
 
 /**
- * A data structure that support replacing it's content.
+ * A data structure that support replacing its content.
  * Primarily used to support hudson.util.PersistedList, which can be exposed as public final fields, but still
  * (re)configured by stapler on structured form submission.
  *

--- a/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
@@ -413,7 +413,7 @@ public class RequestImpl extends HttpServletRequestWrapper implements StaplerReq
             // use the designated constructor for databinding
             for( int i=0; i<len; i++ )
                 r.add(bindParameters(type,prefix,i));
-        } catch (NoStaplerConstructorException _) {
+        } catch (NoStaplerConstructorException ex) {
             // no designated data binding constructor. use reflection
             try {
                 for( int i=0; i<len; i++ ) {

--- a/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
@@ -891,26 +891,6 @@ public class RequestImpl extends HttpServletRequestWrapper implements StaplerReq
         return json;
     }
 
-    private Method findDataBoundSetter(Class c, String name) {
-        // look for public setter that has the matching name
-        for ( ; c!=null; c=c.getSuperclass()) {
-            for (Method m : c.getDeclaredMethods()) {
-                if (!Modifier.isPublic(m.getModifiers())
-                 || !m.getName().startsWith("set")
-                 || m.getParameterTypes().length!=1
-                 || !m.isAnnotationPresent(DataBoundSetter.class))
-                    continue;
-
-                String propertyName = Introspector.decapitalize(m.getName().substring(3));
-                if (!name.equals(propertyName))
-                    continue;   // not the name we are looking for
-
-                return m;
-            }
-        }
-        return null;
-    }
-
     /**
      * Invoke PostConstruct method from the base class to subtypes.
      */

--- a/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
@@ -878,8 +878,13 @@ public class RequestImpl extends HttpServletRequestWrapper implements StaplerReq
             if (!violations.isEmpty()) throw new ConstraintsValidationException(violations);
 
             f.setAccessible(true);
-            f.set(r, value);
-        } catch (IllegalAccessException e) {
+            final Object o = f.get(r);
+            if (o instanceof Replaceable) {
+                ((Replaceable) o).replaceBy(value);
+            } else {
+                f.set(r, value);
+            }
+        } catch (IllegalAccessException | IOException e) {
             LOGGER.log(WARNING, "Cannot access property " + name + " of " + r.getClass(), e);
         }
     }

--- a/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/RequestImpl.java
@@ -36,6 +36,7 @@ import org.apache.commons.fileupload.FileItem;
 import org.apache.commons.fileupload.FileUploadException;
 import org.apache.commons.fileupload.disk.DiskFileItemFactory;
 import org.apache.commons.fileupload.servlet.ServletFileUpload;
+import org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator;
 import org.jvnet.tiger_types.Lister;
 import org.kohsuke.stapler.bind.BoundObjectTable;
 import org.kohsuke.stapler.lang.Klass;
@@ -47,6 +48,8 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.Validation;
+import javax.validation.Validator;
 import java.beans.Introspector;
 import java.beans.PropertyDescriptor;
 import java.io.IOException;
@@ -118,6 +121,12 @@ public class RequestImpl extends HttpServletRequestWrapper implements StaplerReq
     private Map<String, String> parsedFormDataFormFields;
 
     private BindInterceptor bindInterceptor = BindInterceptor.NOOP;
+
+    private static final Validator validator = Validation.byDefaultProvider()
+            .configure()
+            .messageInterpolator(new ParameterMessageInterpolator())
+            .buildValidatorFactory()
+            .getValidator();
 
     public RequestImpl(Stapler stapler, HttpServletRequest request, List<AncestorImpl> ancestors, TokenList tokens) {
         super(request);
@@ -839,6 +848,9 @@ public class RequestImpl extends HttpServletRequestWrapper implements StaplerReq
                 }
             }
         }
+
+        final Set violations = validator.validate(r);
+        if (!violations.isEmpty()) throw new ConstraintsValidationException(violations);
 
         invokePostConstruct(getWebApp().getMetaClass(r).getPostConstructMethods(), r);
 

--- a/core/src/main/java/org/kohsuke/stapler/Trim.java
+++ b/core/src/main/java/org/kohsuke/stapler/Trim.java
@@ -1,0 +1,17 @@
+package org.kohsuke.stapler;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Annotated field or parameter will be automatically trimmed to null before value is used for data-binding.
+ * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
+ */
+@Retention(RUNTIME)
+@Target({FIELD, PARAMETER})
+public @interface Trim {
+}

--- a/core/src/main/java/org/kohsuke/stapler/export/TypeUtil.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/TypeUtil.java
@@ -82,26 +82,26 @@ public class TypeUtil {
      * Implements the logic for {@link #erasure(Type)}.
      */
     private static final TypeVisitor<Class,Void> eraser = new TypeVisitor<Class,Void>() {
-        public Class onClass(Class c,Void _) {
+        public Class onClass(Class c,Void v) {
             return c;
         }
 
-        public Class onParameterizedType(ParameterizedType p,Void _) {
+        public Class onParameterizedType(ParameterizedType p,Void v) {
             // TODO: why getRawType returns Type? not Class?
             return visit(p.getRawType(),null);
         }
 
-        public Class onGenericArray(GenericArrayType g,Void _) {
+        public Class onGenericArray(GenericArrayType g,Void v) {
             return Array.newInstance(
                 visit(g.getGenericComponentType(),null),
                 0 ).getClass();
         }
 
-        public Class onVariable(TypeVariable v,Void _) {
-            return visit(v.getBounds()[0],null);
+        public Class onVariable(TypeVariable t,Void v) {
+            return visit(t.getBounds()[0],null);
         }
 
-        public Class onWildcard(WildcardType w,Void _) {
+        public Class onWildcard(WildcardType w,Void v) {
             return visit(w.getUpperBounds()[0],null);
         }
     };

--- a/core/src/main/resources/META-INF/services/javax.validation.MessageInterpolator
+++ b/core/src/main/resources/META-INF/services/javax.validation.MessageInterpolator
@@ -1,0 +1,1 @@
+org.hibernate.validator.messageinterpolation.ParameterMessageInterpolator

--- a/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
@@ -334,7 +334,7 @@ public class DataBindingTest extends TestCase {
     public static class BeanValidation {
 
         @DataBoundSetter
-        @Positive
+        @Positive @DefaultValue("1")
         private int x;
 
         @DataBoundSetter
@@ -352,16 +352,22 @@ public class DataBindingTest extends TestCase {
     }
 
     public void testFieldInjectionWithValidation() {
-        BeanValidation r = bind("{x:1,y:'2',z:'3'} }",BeanValidation.class);
+        BeanValidation r = bind("{x:1,y:'2',z:'3'} }", BeanValidation.class);
         r.assertValues();
+    }
 
+    public void testFieldInjectionWithValidationFailure() {
         try {
             bind("{x:0,y:' ',z:'foo'} }", BeanValidation.class);
             fail("validation was expected to fail.");
         } catch (IllegalArgumentException e) {
             System.out.println(e.getCause());
         }
+    }
 
+    public void testFieldInjectionWithDefaultValue() {
+        BeanValidation r = bind("{y:'2',z:'3'} }",BeanValidation.class);
+        r.assertValues();
     }
 
 

--- a/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
@@ -5,6 +5,12 @@ import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
 import javax.annotation.PostConstruct;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Positive;
+import javax.validation.constraints.Size;
 import java.lang.reflect.Type;
 import java.net.Proxy;
 import java.util.ArrayList;
@@ -324,6 +330,40 @@ public class DataBindingTest extends TestCase {
         r.assertValues();
         assertEquals(10,r.post);
     }
+
+    public static class BeanValidation {
+
+        @DataBoundSetter
+        @Positive
+        private int x;
+
+        @DataBoundSetter
+        @NotBlank
+        private String y;
+
+        @DataBoundSetter
+        private String z;
+
+        void assertValues() {
+            assertEquals(1,x);
+            assertEquals("2",y);
+            assertEquals("3",z);
+        }
+    }
+
+    public void testFieldInjectionWithValidation() {
+        BeanValidation r = bind("{x:1,y:'2',z:'3'} }",BeanValidation.class);
+        r.assertValues();
+
+        try {
+            bind("{x:0,y:' ',z:'foo'} }", BeanValidation.class);
+            fail("validation was expected to fail.");
+        } catch (IllegalArgumentException e) {
+            System.out.println(e.getCause());
+        }
+
+    }
+
 
     public void testInterceptor1() {
         String r = bind("{x:1}", String.class, new BindInterceptor() {

--- a/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
@@ -333,6 +333,11 @@ public class DataBindingTest extends TestCase {
 
     public static class BeanValidation {
 
+
+        @DataBoundSetter
+        @Trim @DefaultValue("test")
+        private String w;
+
         @DataBoundSetter
         @Positive @DefaultValue("1")
         private int x;
@@ -345,6 +350,7 @@ public class DataBindingTest extends TestCase {
         private String z;
 
         void assertValues() {
+            assertEquals("test",w);
             assertEquals(1,x);
             assertEquals("2",y);
             assertEquals("3",z);
@@ -370,6 +376,10 @@ public class DataBindingTest extends TestCase {
         r.assertValues();
     }
 
+    public void testFieldInjectionTrimToNull() {
+        BeanValidation r = bind("{w:'  ',x:1,y:'2',z:'3'} }", BeanValidation.class);
+        r.assertValues();
+    }
 
     public void testInterceptor1() {
         String r = bind("{x:1}", String.class, new BindInterceptor() {

--- a/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DataBindingTest.java
@@ -312,9 +312,6 @@ public class DataBindingTest extends TestCase {
     }
 
     public static class Point3Derived extends Point3 {
-        @DataBoundConstructor
-        public Point3Derived() {
-        }
 
         @PostConstruct
         private void post1() {
@@ -372,8 +369,6 @@ public class DataBindingTest extends TestCase {
 
     public static class AsymmetricProperty {
         private final List<Integer> items = new ArrayList<Integer>();
-        @DataBoundConstructor
-        public AsymmetricProperty() {}
 
         public List<Integer> getItems() {
             return items;
@@ -395,8 +390,6 @@ public class DataBindingTest extends TestCase {
     }
 
     public static class DerivedProperty extends AsymmetricProperty {
-        @DataBoundConstructor
-        public DerivedProperty() {}
 
         @Override
         public void setItems(Collection<Integer> v) {

--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,8 @@
           <version>2.18.1</version>
           <configuration>
             <trimStackTrace>false</trimStackTrace>
+            <!-- SUREFIRE-1588 workaround; too late for systemProperties: -->
+            <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
this PR introduce support for bean-validation (jsr-303) annotations on databound fields, to prevent invalid values being set by data-binding without need for hand-written validation logic

In addition it also introduce two "transformation" annotations:
- `@Trim` to replace need for `Utils.trimToNull` and make constructor / setters simpler
- `@DefaultValue` to let developers define a default value to be used when not set by form (or trimmed to null). Could be used by Jenkins jelly tags to fill default value in web forms

This is the "_make plugin development simpler/safer_" part of [JEP-205](https://github.com/jenkinsci/jep/tree/master/jep/205)