### PR TITLE
Actually allow returning null from StaplerProxy

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/Stapler.java
+++ b/core/src/main/java/org/kohsuke/stapler/Stapler.java
@@ -697,9 +697,11 @@ public class Stapler extends HttpServlet {
                 else
                     throw e;    // unprocessed exception
             }
-            if(n==node || n==null) {
+            if (n == node) {
                 // if the proxy returns itself, assume that it doesn't want to proxy.
+            } else if (n == null) {
                 // if null, no one will handle the request
+                return false;
             } else {
                 // recursion helps debugging by leaving the trace in the stack.
                 invoke(req,rsp,n);


### PR DESCRIPTION
It seems Stapler documents returning `null` from `getTarget()` to backtrack (or abort dispatching), but in reality, it doesn't work that way: It's the same as returning `this`.

I noticed this bug when trying to conditionally have an object not handle a request at all (when the user has no permission to `Item/Read` it) and fall back to Stapler failing to route.

Upstream of https://github.com/jenkinsci/jenkins/pull/3690