### PR TITLE
Always reject the #getClass() method

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/MetaClass.java
+++ b/core/src/main/java/org/kohsuke/stapler/MetaClass.java
@@ -182,7 +182,7 @@ public class MetaClass extends TearOffSupport {
             });
         }
 
-        FunctionList getMethods = node.methods.prefix("get");
+        FunctionList getMethods = node.methods.prefix("get").filter(m -> !m.getSignature().equals("method java.lang.Object getClass"));
         FunctionList filteredGetMethods;
         if(LEGACY_GETTER_MODE || webApp.getFilterForGetMethods() == null){
             LOGGER.log(Level.FINE, "Stapler is using the legacy GETTER_MODE");

--- a/core/src/main/java/org/kohsuke/stapler/MetaClass.java
+++ b/core/src/main/java/org/kohsuke/stapler/MetaClass.java
@@ -195,9 +195,7 @@ public class MetaClass extends TearOffSupport {
     
                 if(!excludedByNew.isEmpty()){
                     for (Function excluded : excludedByNew) {
-                        if(!excluded.getName().equals("getClass")){
-                            LOGGER.log(Level.FINER, "The following method is now blocked: {0}", excluded.getDisplayName());
-                        }
+                        LOGGER.log(Level.FINER, "The following method is now blocked: {0}", excluded.getDisplayName());
                     }
                 }
             }

--- a/core/src/test/java/org/kohsuke/stapler/MetaClassTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/MetaClassTest.java
@@ -1,0 +1,17 @@
+package org.kohsuke.stapler;
+
+import junit.framework.TestCase;
+import org.junit.Assert;
+import org.kohsuke.stapler.lang.Klass;
+
+public class MetaClassTest extends TestCase {
+    public void testGetObjectProhibited() throws Exception {
+        MetaClass metaClass = new MetaClass(new WebApp(new MockServletContext()), Klass.java(Object.class));
+
+        // ensure no getClass dispatcher for Object
+        Assert.assertFalse(metaClass.dispatchers.stream().filter(d -> d instanceof NameBasedDispatcher).anyMatch(d -> ((NameBasedDispatcher) d).name.equals("class")));
+
+        // in fact, there should be no name based dispatchers at all
+        Assert.assertFalse(metaClass.dispatchers.stream().anyMatch(d -> d instanceof NameBasedDispatcher));
+    }
+}


### PR DESCRIPTION
There seems to be no legitimate use case for allowing `#getClass()` to be called, and not allowing it will make the following statement true:

> It's a fundamental property in Stapler's use of naming convention for its routing, and carefully written applications can just not expose public fields or methods matching the conventional `getWhatever` name on objects they make reachable through routing unless they're intended to be routed, and thereby sidestep the problem.

https://github.com/stapler/stapler/issues/153#issuecomment-445966538 has a more limited variant of that, and there's no reason it should not be true.

Untested.

@Wadeck 