### PR TITLE
Added DispatcherTest.testProtectedMethodDispatch

### DIFF
--- a/core/src/test/java/org/kohsuke/stapler/DispatcherTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/DispatcherTest.java
@@ -366,6 +366,26 @@ public class DispatcherTest extends JettyTestCase {
         }
     }
 
+    public void testProtectedMethodDispatch() throws Exception {
+        WebClient wc = new WebClient();
+        wc.getPage(new URL(url, "public/value"));
+        try {
+            wc.getPage(new URL(url, "protected/value"));
+            fail("should not have allowed protected access");
+        } catch (FailingHttpStatusCodeException x) {
+            assertEquals(HttpServletResponse.SC_NOT_FOUND, x.getStatusCode());
+        }
+        try {
+            wc.getPage(new URL(url, "private/value"));
+            fail("should not have allowed private access");
+        } catch (FailingHttpStatusCodeException x) {
+            assertEquals(HttpServletResponse.SC_NOT_FOUND, x.getStatusCode());
+        }
+    }
+    public TestClass getPublic() {return new TestClass();}
+    protected TestClass getProtected() {return new TestClass();}
+    private TestClass getPrivate() {return new TestClass();}
+
     //===================================================================
 
     public final StaplerProxyImpl staplerProxyOK = new StaplerProxyImpl(new IndexPage());

--- a/pom.xml
+++ b/pom.xml
@@ -201,6 +201,8 @@
           <version>2.18.1</version>
           <configuration>
             <trimStackTrace>false</trimStackTrace>
+            <!-- SUREFIRE-1588 workaround; too late for systemProperties: -->
+            <argLine>-Djdk.net.URLClassPath.disableClassPathURLCheck=true</argLine>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
Clarifies behavior of aca8c023adbc051c80a5e1d785ca76411ff9ed32 based on [this check](https://github.com/stapler/stapler/blob/cebe82d8aee82f93797f315a230fcc74ff950f64/core/src/main/java/org/kohsuke/stapler/ClassDescriptor.java#L168).