### PR TITLE
Add incrementals

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,6 +2,6 @@
   <extension>
     <groupId>io.jenkins.tools.incrementals</groupId>
     <artifactId>git-changelist-maven-extension</artifactId>
-    <version>1.0-beta-2</version>
+    <version>1.0-beta-7</version>
   </extension>
 </extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,7 @@
+<extensions xmlns="http://maven.apache.org/EXTENSIONS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/EXTENSIONS/1.0.0 http://maven.apache.org/xsd/core-extensions-1.0.0.xsd">
+  <extension>
+    <groupId>io.jenkins.tools.incrementals</groupId>
+    <artifactId>git-changelist-maven-extension</artifactId>
+    <version>1.0-beta-2</version>
+  </extension>
+</extensions>

--- a/.mvn/maven.config
+++ b/.mvn/maven.config
@@ -1,0 +1,2 @@
+-Pconsume-incrementals
+-Pmight-produce-incrementals

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kohsuke.stapler</groupId>
     <artifactId>stapler-parent</artifactId>
-    <version>1.257-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
   </parent>
   
   <artifactId>stapler</artifactId>

--- a/groovy/pom.xml
+++ b/groovy/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kohsuke.stapler</groupId>
     <artifactId>stapler-parent</artifactId>
-    <version>1.257-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
   </parent>
   
   <artifactId>stapler-groovy</artifactId>

--- a/jelly/pom.xml
+++ b/jelly/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kohsuke.stapler</groupId>
     <artifactId>stapler-parent</artifactId>
-    <version>1.257-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
   </parent>
 
   <artifactId>stapler-jelly</artifactId>

--- a/jrebel/pom.xml
+++ b/jrebel/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kohsuke.stapler</groupId>
     <artifactId>stapler-parent</artifactId>
-    <version>1.257-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
   </parent>
   
   <artifactId>stapler-jrebel</artifactId>

--- a/jruby/pom.xml
+++ b/jruby/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kohsuke.stapler</groupId>
     <artifactId>stapler-parent</artifactId>
-    <version>1.257-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
   </parent>
 
   <artifactId>stapler-jruby</artifactId>

--- a/jsp/pom.xml
+++ b/jsp/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.kohsuke.stapler</groupId>
     <artifactId>stapler-parent</artifactId>
-    <version>1.257-SNAPSHOT</version>
+    <version>${revision}${changelist}</version>
   </parent>
   
   <artifactId>stapler-jsp</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <groupId>org.kohsuke.stapler</groupId>
   <artifactId>stapler-parent</artifactId>
   <packaging>pom</packaging>
-  <version>1.257-SNAPSHOT</version>
+  <version>${revision}${changelist}</version>
 
   <name>Stapler</name>
   <description>Stapler HTTP request handling engine</description>
@@ -37,7 +37,7 @@
     <connection>scm:git:git://github.com/stapler/stapler.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/stapler/stapler.git</developerConnection>
     <url>https://github.com/stapler/stapler</url>
-    <tag>HEAD</tag>
+    <tag>${scmTag}</tag>
   </scm>
 
   <prerequisites>
@@ -84,6 +84,10 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.level>8</java.level>
+    <revision>1.257</revision>
+    <changelist>-SNAPSHOT</changelist>
+    <incrementals.url>https://repo.jenkins-ci.org/incrementals/</incrementals.url>
+    <scmTag>HEAD</scmTag>
   </properties>
 
   <build>
@@ -281,4 +285,141 @@
     </dependency>
   </dependencies>
   </dependencyManagement>
+
+  <profiles>
+    <profile>
+      <!-- JEP-305 -->
+      <id>consume-incrementals</id>
+      <repositories>
+        <repository>
+          <id>incrementals</id>
+          <url>${incrementals.url}</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </repository>
+      </repositories>
+      <pluginRepositories>
+        <pluginRepository>
+          <id>incrementals</id>
+          <url>${incrementals.url}</url>
+          <snapshots>
+            <enabled>false</enabled>
+          </snapshots>
+        </pluginRepository>
+      </pluginRepositories>
+    </profile>
+    <profile>
+      <id>might-produce-incrementals</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.codehaus.mojo</groupId>
+            <artifactId>flatten-maven-plugin</artifactId>
+            <version>1.0.1</version>
+            <configuration>
+              <updatePomFile>true</updatePomFile>
+            </configuration>
+            <executions>
+              <execution>
+                <id>flatten</id>
+                <phase>process-resources</phase>
+                <goals>
+                  <goal>flatten</goal>
+                </goals>
+                <configuration>
+                  <flattenMode>oss</flattenMode>
+                  <outputDirectory>${project.build.directory}</outputDirectory>
+                  <flattenedPomFilename>${project.artifactId}-${project.version}.pom</flattenedPomFilename>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>display-info</id>
+                <configuration>
+                  <rules>
+                    <requireMavenVersion>
+                      <version>[3.5.0,)</version>
+                      <message>3.5.0+ required to use Incrementals.</message>
+                    </requireMavenVersion>
+                    <rule implementation="io.jenkins.tools.incrementals.enforcer.RequireExtensionVersion">
+                      <version>[1.0-beta-4,)</version>
+                    </rule>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+            <dependencies>
+              <dependency>
+                <groupId>io.jenkins.tools.incrementals</groupId>
+                <artifactId>incrementals-enforcer-rules</artifactId>
+                <version>1.0-beta-4</version>
+              </dependency>
+            </dependencies>
+          </plugin>
+          <plugin>
+            <artifactId>maven-release-plugin</artifactId>
+            <configuration>
+              <completionGoals>incrementals:reincrementalify</completionGoals>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>produce-incrementals</id>
+      <activation>
+        <property>
+          <name>set.changelist</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <distributionManagement>
+        <repository>
+          <id>incrementals</id>
+          <url>${incrementals.url}</url>
+        </repository>
+      </distributionManagement>
+      <build>
+        <plugins>
+          <!-- Copied from jenkins-release: -->
+          <plugin>
+            <artifactId>maven-source-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-sources</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+              <execution>
+                <id>attach-test-sources</id>
+                <goals>
+                  <goal>test-jar-no-fork</goal>
+                </goals>
+                <configuration>
+                  <skipSource>${no-test-jar}</skipSource>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-javadoc-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -357,7 +357,7 @@
               <dependency>
                 <groupId>io.jenkins.tools.incrementals</groupId>
                 <artifactId>incrementals-enforcer-rules</artifactId>
-                <version>1.0-beta-4</version>
+                <version>1.0-beta-5</version>
               </dependency>
             </dependencies>
           </plugin>


### PR DESCRIPTION
I'd like to incrementalize stapler. This will be handy in general and will make it easier to do some other changes we want.

Since stapler isn't a plugin, I couldn't follow the easy mechanism. Instead I followed the step-by-step, manual instructions. The changes match what I've seen the automated, easy version do, plus the addition of the profiles needed because the parent is different.

While I've used this to effectively generate incrementals locally I don't know that it is sufficient to automatically generate them in Jenkins CI environment. Specifically, updates my be required for the stapler settings in repository-permissions-updater.

Do we want a Jira ticket associated with this change?