### PR TITLE
Make LocaleDrivenResourceProvider quieter

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/LocaleDrivenResourceProvider.java
+++ b/core/src/main/java/org/kohsuke/stapler/LocaleDrivenResourceProvider.java
@@ -63,7 +63,7 @@ public abstract class LocaleDrivenResourceProvider {
             localeDrivenResourceProviders = new ArrayList<>();
             for (LocaleDrivenResourceProvider provider : ServiceLoader.load(LocaleDrivenResourceProvider.class)) {
                 localeDrivenResourceProviders.add(provider);
-                LOGGER.log(Level.INFO, "Registered LocaleDrivenResourceProvider: " + provider);
+                LOGGER.fine(() -> "Registered LocaleDrivenResourceProvider: " + provider);
             }
         }
         return localeDrivenResourceProviders;


### PR DESCRIPTION
Was irritated to see an extra message in the Jenkins startup log. https://github.com/stapler/stapler/pull/156#discussion_r273059383