### PR TITLE
[JENKINS-53322] Use standard dom4j distribution.

### DIFF
--- a/jelly/pom.xml
+++ b/jelly/pom.xml
@@ -32,9 +32,9 @@
       <artifactId>commons-collections</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.jenkins-ci.dom4j</groupId>
+      <groupId>org.dom4j</groupId>
       <artifactId>dom4j</artifactId>
-      <version>1.6.1-jenkins-4</version>
+      <version>2.1.1</version>
     </dependency>
     <dependency><!-- only needed for annotations, hence optional -->
       <groupId>org.jvnet.maven-jellydoc-plugin</groupId>

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/ContentTypeTag.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/ContentTypeTag.java
@@ -52,7 +52,5 @@ public class ContentTypeTag extends AbstractStaplerTag {
         HttpServletResponse rsp = getResponse();
         if (rsp!=null)
             rsp.setContentType(contentType);
-        if (output instanceof HTMLWriterOutput)
-            ((HTMLWriterOutput)output).useHTML(contentType.startsWith("text/html"));
     }
 }

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/DefaultScriptInvoker.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/DefaultScriptInvoker.java
@@ -24,14 +24,14 @@
 package org.kohsuke.stapler.jelly;
 
 import org.apache.commons.jelly.JellyContext;
-import org.apache.commons.jelly.JellyTagException;
-import org.apache.commons.jelly.Script;
-import org.apache.commons.jelly.XMLOutput;
-import org.apache.commons.jelly.XMLOutputFactory;
-import org.apache.commons.jelly.impl.TagScript;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;
+import org.apache.commons.jelly.Script;
+import org.apache.commons.jelly.JellyTagException;
+import org.apache.commons.jelly.XMLOutput;
+import org.apache.commons.jelly.XMLOutputFactory;
+import org.apache.commons.jelly.impl.TagScript;
 
 import javax.annotation.Nonnull;
 import javax.servlet.ServletContext;
@@ -65,11 +65,15 @@ public class DefaultScriptInvoker implements ScriptInvoker, XMLOutputFactory {
 
     protected XMLOutput createXMLOutput(StaplerRequest req, StaplerResponse rsp, Script script, Object it) throws IOException {
         // TODO: make XMLOutput auto-close OutputStream to avoid leak
-        HTMLWriterOutput hwo = HTMLWriterOutput.create(createOutputStream(req, rsp, script, it));
         String ct = rsp.getContentType();
-        if (ct != null && !ct.startsWith("text/html"))
-            hwo.useHTML(false);
-        return hwo;
+        XMLOutput output;
+        if (ct != null && !ct.startsWith("text/html")) {
+            output = XMLOutput.createXMLOutput(createOutputStream(req, rsp, script, it));
+        } else {
+            output = HTMLWriterOutput.create(createOutputStream(req, rsp, script, it));
+
+        }
+        return output;
     }
 
     private boolean doCompression(Script script) {

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/HTMLWriterOutput.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/HTMLWriterOutput.java
@@ -76,6 +76,6 @@ public class HTMLWriterOutput extends XMLOutput {
 
     @Deprecated
     public void useHTML(boolean enabled) {
-        LOGGER.fine("Deprecated: HTMLWriterOutput.useHtml() has been deprecated and its functionality removed.");
+        LOGGER.log(Level. WARNING, null, new UnsupportedOperationException("Deprecated: HTMLWriterOutput.useHtml() has been deprecated and its functionality removed."));
     }
 }

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/HTMLWriterOutput.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/HTMLWriterOutput.java
@@ -64,18 +64,11 @@ public class HTMLWriterOutput extends XMLOutput {
         hw.setEscapeText(escapeText);
         this.htmlWriter = hw;
         this.format = fmt;
+        format.setExpandEmptyElements(true);
     }
 
     @Override public void close() throws IOException {
         htmlWriter.close();
     }
 
-    /**
-     * False to turn off HTML handling and reenable {@code />} for any empty XML element.
-     * True to switch back to default mode with HTML handling.
-     */
-    public void useHTML(boolean enabled) {
-        htmlWriter.setEnabled(enabled);
-        format.setExpandEmptyElements(enabled);
-    }
 }

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/HTMLWriterOutput.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/HTMLWriterOutput.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/HTMLWriterOutput.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/HTMLWriterOutput.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.io.Writer;
+import java.util.logging.Logger;
 
 /**
  * Wrapper for XMLOutput using HTMLWriter that can turn off its HTML handling
@@ -40,6 +41,8 @@ import java.io.Writer;
 public class HTMLWriterOutput extends XMLOutput {
     private HTMLWriter htmlWriter;
     private OutputFormat format;
+
+    private static final Logger LOGGER = Logger.getLogger(HTMLWriterOutput.class.getName());
 
     public static HTMLWriterOutput create(OutputStream out) throws UnsupportedEncodingException {
         OutputFormat format = createFormat();
@@ -71,4 +74,8 @@ public class HTMLWriterOutput extends XMLOutput {
         htmlWriter.close();
     }
 
+    @Deprecated
+    public void useHTML(boolean enabled) {
+        LOGGER.fine("Deprecated: HTMLWriterOutput.useHtml() has been deprecated and its functionality removed.");
+    }
 }


### PR DESCRIPTION
See [JENKINS-53322](https://issues.jenkins-ci.org/browse/JENKINS-53322).

I've been working on eliminating the need for the Jenkins-specific fork of dom4j and adopting the latest, standard release, 2.1.1. There are two aspects 1) dealing with the changes in the fork, which are minor and apparently not consequential, and 2) upgrading a couple of places to match changes in the dom4j API since long ago.

I've run a lot of builds and tests on various components to check these changes. I have found a few places that require changes, A) here in Stapler, B), a test in Jenkins core for API changes, C) licensing packaging change in Jenkins, D) and a couple of minor changes in ec2-plugin for API changes. My PR for ec2-plugin jenkinsci/ec2-plugin#372 works on both the old and new API and has already been merged in. See jenkinsci/jenkins#4089 to make B) and C) behave for both old and new dom4j.

The dom4j changes in the Jenkins don't make any sense. There is another way to do about the same thing, as demonstrated by this PR. The object model makes more sense if the appropriate class is chosen rather than trying to make the one class behave more like the other. Significantly, I can't find any evidence that the modification is ever actually used. There are no tests in the dom4j fork to validate it. The Stapler tests, limited as they are, pass with these changes and do not run through the paths introduced in the Jenkins dom4j fork. The same is true for tests within the Jenkins project and the UI testing I've performed. Where possible, I've compiled and testing plugins or libraries with dependencies or references to dom4j and found no further problems.

This PR cannot be included in Jenkins (via an updated Stapler) version until jenkinsci/jenkins#4089 to resolve B) and C) is merged.