### PR TITLE
Upgrade to latest commons-beanutils.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>1.8.3</version>
+      <version>1.9.4</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>


### PR DESCRIPTION
Pick up the latest improvements and hardenings.

Jenkins appears to package the version referenced in jenkins/core. Maybe this one, but probably not. It would be good to go ahead and update this one for the next stapler release.