### PR TITLE
[ISSUE-179] Improve message regarding duplicated annotated constructors

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/jsr269/ConstructorProcessor.java
+++ b/core/src/main/java/org/kohsuke/stapler/jsr269/ConstructorProcessor.java
@@ -3,6 +3,7 @@ package org.kohsuke.stapler.jsr269;
 import org.kohsuke.MetaInfServices;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import javax.annotation.processing.FilerException;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
@@ -96,7 +97,9 @@ public class ConstructorProcessor extends AbstractProcessorImpl {
             Properties p = new Properties();
             p.put("constructor",buf.toString());
             writePropertyFile(p, name);
-        } catch (IOException x) {
+        } catch (FilerException fe) {
+            error(new IOException("Only one annotated constructor (@stapler-constructor or @DataBoundConstructor) is allowed per class", fe));
+        } catch(IOException x) {
             error(x);
         }
     }

--- a/core/src/main/java/org/kohsuke/stapler/jsr269/ConstructorProcessor.java
+++ b/core/src/main/java/org/kohsuke/stapler/jsr269/ConstructorProcessor.java
@@ -3,7 +3,6 @@ package org.kohsuke.stapler.jsr269;
 import org.kohsuke.MetaInfServices;
 import org.kohsuke.stapler.DataBoundConstructor;
 
-import javax.annotation.processing.FilerException;
 import javax.annotation.processing.Processor;
 import javax.annotation.processing.RoundEnvironment;
 import javax.annotation.processing.SupportedAnnotationTypes;
@@ -27,18 +26,23 @@ import javax.tools.Diagnostic;
 @SupportedAnnotationTypes("*")
 @MetaInfServices(Processor.class)
 public class ConstructorProcessor extends AbstractProcessorImpl {
+   /* private */ final static String MESSAGE = "Only one annotated constructor (@DataBoundConstructor annotation or @stapler-constructor javadoc) is permitted per class";
+
     @Override
     public boolean process(Set<? extends TypeElement> annotations, RoundEnvironment roundEnv) {
         try {
             ElementScanner6<Void, Void> scanner = new ElementScanner6<Void, Void>() {
+                boolean written;
+                boolean messagePrinted;
+                
                 @Override
                 public Void visitExecutable(ExecutableElement e, Void aVoid) {
                     if(e.getAnnotation(DataBoundConstructor.class)!=null) {
-                        write(e);
+                        writeOrAddOnlyOneMessage(e);
                     } else {
                         String javadoc = getJavadoc(e);
                         if(javadoc!=null && javadoc.contains("@stapler-constructor")) {
-                            write(e);
+                            writeOrAddOnlyOneMessage(e);
                         }
                     }
 
@@ -48,6 +52,16 @@ public class ConstructorProcessor extends AbstractProcessorImpl {
                 @Override
                 public Void visitUnknown(Element e, Void aVoid) {
                     return DEFAULT_VALUE;
+                }
+
+                private void writeOrAddOnlyOneMessage(ExecutableElement e) {
+                    if (!written) {
+                        write(e);
+                        written = true;
+                    } else if (!messagePrinted){
+                        processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, MESSAGE, e);
+                        messagePrinted = true;
+                    }
                 }
             };
 
@@ -97,8 +111,6 @@ public class ConstructorProcessor extends AbstractProcessorImpl {
             Properties p = new Properties();
             p.put("constructor",buf.toString());
             writePropertyFile(p, name);
-        } catch (FilerException fe) {
-            error(new IOException("Only one annotated constructor (@stapler-constructor or @DataBoundConstructor) is allowed per class", fe));
         } catch(IOException x) {
             error(x);
         }

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/ConstructorProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/ConstructorProcessorTest.java
@@ -95,7 +95,7 @@ public class ConstructorProcessorTest {
         List<Diagnostic<? extends JavaFileObject>> diagnostics = compilation.getDiagnostics();
         assertEquals(1, diagnostics.size());
         String msg = diagnostics.get(0).getMessage(Locale.ENGLISH);
-        assertTrue(msg, msg.contains("Only one annotated constructor"));
+        assertTrue(msg, msg.contains(ConstructorProcessor.MESSAGE));
     }
 
     //issue-1779
@@ -115,7 +115,7 @@ public class ConstructorProcessorTest {
         List<Diagnostic<? extends JavaFileObject>> diagnostics = compilation.getDiagnostics();
         assertEquals(1, diagnostics.size());
         String msg = diagnostics.get(0).getMessage(Locale.ENGLISH);
-        assertTrue(msg, msg.contains("Only one annotated constructor"));
+        assertTrue(msg, msg.contains(ConstructorProcessor.MESSAGE));
     }
 
     //issue-1779

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/ConstructorProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/ConstructorProcessorTest.java
@@ -133,6 +133,4 @@ public class ConstructorProcessorTest {
         assertEquals(0, diagnostics.size());
     }
     // TODO nested classes use qualified rather than binary name
-    // TODO behavior when multiple @DataBoundConstructor's specified on a single class - error?
-
 }

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/ConstructorProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/ConstructorProcessorTest.java
@@ -95,7 +95,7 @@ public class ConstructorProcessorTest {
         List<Diagnostic<? extends JavaFileObject>> diagnostics = compilation.getDiagnostics();
         assertEquals(1, diagnostics.size());
         String msg = diagnostics.get(0).getMessage(Locale.ENGLISH);
-        assertTrue(msg, msg.contains(ConstructorProcessor.MESSAGE));
+        assertTrue(msg, msg.contains("Only one annotated constructor"));
     }
 
     //issue-1779
@@ -115,7 +115,7 @@ public class ConstructorProcessorTest {
         List<Diagnostic<? extends JavaFileObject>> diagnostics = compilation.getDiagnostics();
         assertEquals(1, diagnostics.size());
         String msg = diagnostics.get(0).getMessage(Locale.ENGLISH);
-        assertTrue(msg, msg.contains(ConstructorProcessor.MESSAGE));
+        assertTrue(msg, msg.contains("Only one annotated constructor"));
     }
 
     //issue-1779

--- a/core/src/test/java/org/kohsuke/stapler/jsr269/ConstructorProcessorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/jsr269/ConstructorProcessorTest.java
@@ -81,6 +81,57 @@ public class ConstructorProcessorTest {
         assertTrue(msg, msg.contains("abstract"));
     }
 
+    //issue-1779
+    @Test public void duplicatedConstructor1() {
+        Compilation compilation = new Compilation();
+        compilation.addSource("some.pkg.Stuff").
+                addLine("package some.pkg;").
+                addLine("import org.kohsuke.stapler.DataBoundConstructor;").
+                addLine("public class Stuff {").
+                addLine("  @DataBoundConstructor public Stuff() {}").
+                addLine("  @DataBoundConstructor public Stuff(int i) {}").
+                addLine("}");
+        compilation.doCompile(null, "-source", "6");
+        List<Diagnostic<? extends JavaFileObject>> diagnostics = compilation.getDiagnostics();
+        assertEquals(1, diagnostics.size());
+        String msg = diagnostics.get(0).getMessage(Locale.ENGLISH);
+        assertTrue(msg, msg.contains("Only one annotated constructor"));
+    }
+
+    //issue-1779
+    @Test public void duplicatedConstructor2() {
+        Compilation compilation = new Compilation();
+        compilation.addSource("some.pkg.Stuff").
+                addLine("package some.pkg;").
+                addLine("import org.kohsuke.stapler.DataBoundConstructor;").
+                addLine("public class Stuff {").
+                addLine("  @DataBoundConstructor public Stuff() {}").
+                addLine("  /**").
+                addLine("    @stapler-constructor Another constructor"). 
+                addLine("   **/").
+                addLine("  public Stuff(int i) {}").
+                addLine("}");
+        compilation.doCompile(null, "-source", "6");
+        List<Diagnostic<? extends JavaFileObject>> diagnostics = compilation.getDiagnostics();
+        assertEquals(1, diagnostics.size());
+        String msg = diagnostics.get(0).getMessage(Locale.ENGLISH);
+        assertTrue(msg, msg.contains("Only one annotated constructor"));
+    }
+
+    //issue-1779
+    @Test public void duplicatedButNotAnnotatedConstructor() {
+        Compilation compilation = new Compilation();
+        compilation.addSource("some.pkg.Stuff").
+                addLine("package some.pkg;").
+                addLine("import org.kohsuke.stapler.DataBoundConstructor;").
+                addLine("public class Stuff {").
+                addLine("  @DataBoundConstructor public Stuff() {}").
+                addLine("  public Stuff(int i) {}").
+                addLine("}");
+        compilation.doCompile(null, "-source", "6");
+        List<Diagnostic<? extends JavaFileObject>> diagnostics = compilation.getDiagnostics();
+        assertEquals(0, diagnostics.size());
+    }
     // TODO nested classes use qualified rather than binary name
     // TODO behavior when multiple @DataBoundConstructor's specified on a single class - error?
 


### PR DESCRIPTION
Fixes #179

This PR improves the message when you have two annotated constructors in the same class + tests.

The error now is not descriptive:

```
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] javax.annotation.processing.FilerException: Attempt to reopen a file for path /...ClassXXX.stapler
  	at com.sun.tools.javac.processing.JavacFiler.checkFileReopening(JavacFiler.java:535)
```