### PR TITLE
Add spotbugs and findsecbugs

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -165,6 +165,16 @@
       <version>1.2</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
   </dependencies>
 </project>
 

--- a/core/src/main/java/org/kohsuke/stapler/AbstractTearOff.java
+++ b/core/src/main/java/org/kohsuke/stapler/AbstractTearOff.java
@@ -25,9 +25,11 @@ package org.kohsuke.stapler;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
+
 import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/core/src/main/java/org/kohsuke/stapler/AbstractTearOff.java
+++ b/core/src/main/java/org/kohsuke/stapler/AbstractTearOff.java
@@ -25,6 +25,8 @@ package org.kohsuke.stapler;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -157,6 +159,7 @@ public abstract class AbstractTearOff<CLT,S,E extends Exception> extends Caching
     }
 
     private static final Pattern JAR_URL = Pattern.compile("jar:(file:.+)!/.*");
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Files are read from approved plugins, not from user input.")
     private static File fileOf(URL res) {
         try {
             switch (res.getProtocol()) {

--- a/core/src/main/java/org/kohsuke/stapler/AbstractTearOff.java
+++ b/core/src/main/java/org/kohsuke/stapler/AbstractTearOff.java
@@ -25,11 +25,9 @@ package org.kohsuke.stapler;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
-
 import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
-
 import java.net.URL;
 import java.util.logging.Level;
 import java.util.logging.Logger;

--- a/core/src/main/java/org/kohsuke/stapler/AcceptHeader.java
+++ b/core/src/main/java/org/kohsuke/stapler/AcceptHeader.java
@@ -85,8 +85,8 @@ public final class AcceptHeader {
         @Override
         public String toString() {
             StringBuilder s = new StringBuilder(major +'/'+ minor);
-            for (String k : params.keySet())
-                s.append(";").append(k).append("=").append(params.get(k));
+            for (Map.Entry<String, String> k : params.entrySet())
+                s.append(";").append(k.getKey()).append("=").append(k.getValue());
             return s.toString();
         }
 

--- a/core/src/main/java/org/kohsuke/stapler/AncestorImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/AncestorImpl.java
@@ -45,12 +45,15 @@ class AncestorImpl implements Ancestor {
     AncestorImpl(RequestImpl req, Object object) {
         this.owner = req.ancestors;
         listIndex = owner.size();
-        owner.add(this);
         this.object = object;
         this.tokens = req.tokens.rawTokens;
         this.index = req.tokens.idx;
         this.endsWithSlash = req.tokens.endsWithSlash;
         this.contextPath = req.getContextPath();
+    }
+
+    void addToOwner() {
+        owner.add(this);
     }
 
     public Object getObject() {

--- a/core/src/main/java/org/kohsuke/stapler/ClassDescriptor.java
+++ b/core/src/main/java/org/kohsuke/stapler/ClassDescriptor.java
@@ -385,7 +385,7 @@ public final class ClassDescriptor {
         }
     }
 
-    final class MethodMirror {
+    final static class MethodMirror {
         final Signature sig;
         final Method method;
 
@@ -398,7 +398,7 @@ public final class ClassDescriptor {
     /**
      * A method signature used to determine what methods override each other
      */
-    final class Signature {
+    final static class Signature {
         final String methodName;
         final Class[] parameters;
 

--- a/core/src/main/java/org/kohsuke/stapler/Dispatcher.java
+++ b/core/src/main/java/org/kohsuke/stapler/Dispatcher.java
@@ -23,6 +23,8 @@
 
 package org.kohsuke.stapler;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import javax.servlet.ServletException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
@@ -121,6 +123,7 @@ public abstract class Dispatcher {
      * and when the evaluation failed, special diagnostic 404 page will be rendered.
      * Useful for developer assistance.
      */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Used in JTH and others.")
     public static boolean TRACE = Boolean.getBoolean("stapler.trace");
 
     /**
@@ -130,6 +133,7 @@ public abstract class Dispatcher {
      * and when the evaluation failed, special diagnostic 404 page will be rendered.
      * Useful for developer assistance.
      */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Legacy switch.")
     public static boolean TRACE_PER_REQUEST = Boolean.getBoolean("stapler.trace.per-request");
 
     private static final Logger LOGGER = Logger.getLogger(Dispatcher.class.getName());

--- a/core/src/main/java/org/kohsuke/stapler/Facet.java
+++ b/core/src/main/java/org/kohsuke/stapler/Facet.java
@@ -23,6 +23,7 @@
 
 package org.kohsuke.stapler;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.discovery.ResourceNameIterator;
 import org.apache.commons.discovery.resource.ClassLoaders;
 import org.apache.commons.discovery.resource.names.DiscoverServiceNames;
@@ -112,6 +113,7 @@ public abstract class Facet {
 
     public static final Logger LOGGER = Logger.getLogger(Facet.class.getName());
 
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Legacy switch.")
     public static boolean ALLOW_VIEW_NAME_PATH_TRAVERSAL = Boolean.getBoolean(Facet.class.getName() + ".allowViewNamePathTraversal");
     
     /**

--- a/core/src/main/java/org/kohsuke/stapler/ForwardToView.java
+++ b/core/src/main/java/org/kohsuke/stapler/ForwardToView.java
@@ -23,6 +23,8 @@
 
 package org.kohsuke.stapler;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import javax.servlet.ServletException;
 import javax.servlet.RequestDispatcher;
 import java.io.IOException;
@@ -37,8 +39,8 @@ import java.util.Map.Entry;
  * @author Kohsuke Kawaguchi
  */
 public class ForwardToView extends RuntimeException implements HttpResponse {
+    @SuppressFBWarnings(value = "SE_BAD_FIELD", justification = "A valid issue, but complicated to fix now. Not causing any observable problems.")
     private final DispatcherFactory factory;
-    private boolean optional;
     private final Map<String,Object> attributes = new HashMap<String, Object>();
 
     private interface DispatcherFactory {
@@ -86,16 +88,16 @@ public class ForwardToView extends RuntimeException implements HttpResponse {
      * Make this forwarding optional. Render nothing if a view doesn't exist.
      */
     public ForwardToView optional() {
-        optional = true;
         return this;
     }
 
+    @SuppressFBWarnings(value = "REQUESTDISPATCHER_FILE_DISCLOSURE", justification = "Forwarded to a view to handle correctly.")
     public void generateResponse(StaplerRequest req, StaplerResponse rsp, Object node) throws IOException, ServletException {
         for (Entry<String, Object> e : attributes.entrySet())
             req.setAttribute(e.getKey(),e.getValue());
         RequestDispatcher rd = factory.get(req);
-        if (rd==null && optional)
-            return;
-        rd.forward(req, rsp);
+        if (rd != null) {
+            rd.forward(req, rsp);
+        }
     }
 }

--- a/core/src/main/java/org/kohsuke/stapler/ForwardToView.java
+++ b/core/src/main/java/org/kohsuke/stapler/ForwardToView.java
@@ -39,7 +39,7 @@ import java.util.Map.Entry;
  * @author Kohsuke Kawaguchi
  */
 public class ForwardToView extends RuntimeException implements HttpResponse {
-    @SuppressFBWarnings(value = "SE_BAD_FIELD", justification = "A valid issue, but complicated to fix now. Not causing any observable problems.")
+    @SuppressFBWarnings(value = "SE_BAD_FIELD", justification = "As an HttpResponse, this is not actually serialized.")
     private final DispatcherFactory factory;
     private final Map<String,Object> attributes = new HashMap<String, Object>();
 

--- a/core/src/main/java/org/kohsuke/stapler/HttpRedirect.java
+++ b/core/src/main/java/org/kohsuke/stapler/HttpRedirect.java
@@ -23,6 +23,8 @@
 
 package org.kohsuke.stapler;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import javax.annotation.Nonnull;
 import javax.servlet.ServletException;
 import java.io.IOException;
@@ -69,6 +71,7 @@ public final class HttpRedirect extends RuntimeException implements HttpResponse
     /**
      * Redirect to "."
      */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Legacy control.")
     public static HttpRedirect DOT = new HttpRedirect(".");
 
     /**

--- a/core/src/main/java/org/kohsuke/stapler/HttpRedirect.java
+++ b/core/src/main/java/org/kohsuke/stapler/HttpRedirect.java
@@ -71,8 +71,7 @@ public final class HttpRedirect extends RuntimeException implements HttpResponse
     /**
      * Redirect to "."
      */
-    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Legacy control.")
-    public static HttpRedirect DOT = new HttpRedirect(".");
+    public final static HttpRedirect DOT = new HttpRedirect(".");
 
     /**
      * Redirect to the context root

--- a/core/src/main/java/org/kohsuke/stapler/MetaClass.java
+++ b/core/src/main/java/org/kohsuke/stapler/MetaClass.java
@@ -23,6 +23,7 @@
 
 package org.kohsuke.stapler;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import net.sf.json.JSONArray;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
@@ -645,14 +646,17 @@ public class MetaClass extends TearOffSupport {
      * Don't cache anything in memory, so that any change
      * will take effect instantly.
      */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_REFACTORED_TO_BE_FINAL", justification = "Legacy switch.")
     public static boolean NO_CACHE = false;
     /**
      * In case the breaking changes are not desired. They are recommended for security reason.
      */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_REFACTORED_TO_BE_FINAL", justification = "Legacy switch.")
     public static boolean LEGACY_GETTER_MODE = false;
     /**
      * In case the breaking changes are not desired. They are recommended for security reason.
      */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_REFACTORED_TO_BE_FINAL", justification = "Legacy switch.")
     public static boolean LEGACY_WEB_METHOD_MODE = false;
 
     static {

--- a/core/src/main/java/org/kohsuke/stapler/MetaClassLoader.java
+++ b/core/src/main/java/org/kohsuke/stapler/MetaClassLoader.java
@@ -75,6 +75,11 @@ public class MetaClassLoader extends TearOffSupport {
     private static final Map<ClassLoader,MetaClassLoader> classMap = new HashMap<ClassLoader,MetaClassLoader>();
 
     static {
+        debugLoader = createDebugLoader();
+    }
+
+    @SuppressFBWarnings(value = "DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED", justification = "Not used with an installed security manager.")
+    private static MetaClassLoader createDebugLoader() {
         try {
             String path = System.getProperty("stapler.resourcePath");
             if(path!=null) {
@@ -82,10 +87,11 @@ public class MetaClassLoader extends TearOffSupport {
                 URL[] urls = new URL[tokens.length];
                 for (int i=0; i<tokens.length; i++)
                     urls[i] = new File(tokens[i]).toURI().toURL();
-                debugLoader = new MetaClassLoader(new URLClassLoader(urls));
+                return new MetaClassLoader(new URLClassLoader(urls));
             }
         } catch (MalformedURLException e) {
             throw new Error(e);
         }
+        return null;
     }
 }

--- a/core/src/main/java/org/kohsuke/stapler/MetaClassLoader.java
+++ b/core/src/main/java/org/kohsuke/stapler/MetaClassLoader.java
@@ -23,6 +23,8 @@
 
 package org.kohsuke.stapler;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.util.Map;
 import java.io.File;
 import java.net.URLClassLoader;
@@ -62,6 +64,7 @@ public class MetaClassLoader extends TearOffSupport {
     /**
      * If non-null, delegate to this classloader.
      */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_REFACTORED_TO_BE_FINAL", justification = "Legacy switch.")
     public static MetaClassLoader debugLoader = null;
 
     /**

--- a/core/src/main/java/org/kohsuke/stapler/ResponseImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/ResponseImpl.java
@@ -362,7 +362,7 @@ public class ResponseImpl extends HttpServletResponseWrapper implements StaplerR
     }
 
     @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Not relevant in this situation.")
-    private HttpURLConnection openConnection(URL url) throws IOException {
+    private static HttpURLConnection openConnection(URL url) throws IOException {
         return (HttpURLConnection) url.openConnection();
     }
 

--- a/core/src/main/java/org/kohsuke/stapler/ResponseImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/ResponseImpl.java
@@ -192,10 +192,14 @@ public class ResponseImpl extends HttpServletResponseWrapper implements StaplerR
         }
 
         setStatus(statusCode);
-        setHeader("Location", URLEncoder.encode(url, StandardCharsets.UTF_8.name()));
+        setLocation(url);
         getOutputStream().close();
     }
 
+    @SuppressFBWarnings(value = "HTTP_RESPONSE_SPLITTING", justification = "Already encoded and handled.")
+    private void setLocation(@Nonnull String url) {
+        setHeader("Location",url);
+    }
 
     public void serveFile(StaplerRequest req, URL resource, long expiration) throws ServletException, IOException {
         if(!stapler.serveStaticResource(req,this,resource,expiration))

--- a/core/src/main/java/org/kohsuke/stapler/ResponseImpl.java
+++ b/core/src/main/java/org/kohsuke/stapler/ResponseImpl.java
@@ -32,6 +32,8 @@ import java.io.PrintWriter;
 import java.io.Writer;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
@@ -44,6 +46,7 @@ import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpServletResponseWrapper;
 
 import com.jcraft.jzlib.GZIPOutputStream;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import net.sf.json.JsonConfig;
 import org.apache.commons.io.IOUtils;
 import org.kohsuke.stapler.compression.CompressionFilter;
@@ -189,7 +192,7 @@ public class ResponseImpl extends HttpServletResponseWrapper implements StaplerR
         }
 
         setStatus(statusCode);
-        setHeader("Location",url);
+        setHeader("Location", URLEncoder.encode(url, StandardCharsets.UTF_8.name()));
         getOutputStream().close();
     }
 
@@ -325,7 +328,7 @@ public class ResponseImpl extends HttpServletResponseWrapper implements StaplerR
     }
 
     public int reverseProxyTo(URL url, StaplerRequest req) throws IOException {
-        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        HttpURLConnection con = openConnection(url);
         con.setDoOutput(true);
 
         Enumeration h = req.getHeaderNames();
@@ -344,7 +347,7 @@ public class ResponseImpl extends HttpServletResponseWrapper implements StaplerR
 
         // copy the response
         int code = con.getResponseCode();
-        setStatus(code,con.getResponseMessage());
+        setStatus(con, code);
         Map<String,List<String>> rspHeaders = con.getHeaderFields();
         for (Entry<String, List<String>> header : rspHeaders.entrySet()) {
             if(header.getKey()==null)   continue;   // response line
@@ -356,6 +359,17 @@ public class ResponseImpl extends HttpServletResponseWrapper implements StaplerR
         copyAndClose(con.getInputStream(), getOutputStream());
 
         return code;
+    }
+
+    @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Not relevant in this situation.")
+    private HttpURLConnection openConnection(URL url) throws IOException {
+        return (HttpURLConnection) url.openConnection();
+    }
+
+    @SuppressFBWarnings(value = "XSS_SERVLET", justification = "Not relevant in this situation.")
+    private void setStatus(HttpURLConnection con, int code) throws IOException {
+        // Should also fix the deprecation.
+        setStatus(code,con.getResponseMessage());
     }
 
     public void setJsonConfig(JsonConfig config) {

--- a/core/src/main/java/org/kohsuke/stapler/ScriptRequestDispatcher.java
+++ b/core/src/main/java/org/kohsuke/stapler/ScriptRequestDispatcher.java
@@ -24,6 +24,8 @@
 
 package org.kohsuke.stapler;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 import javax.servlet.RequestDispatcher;
@@ -102,6 +104,7 @@ class ScriptRequestDispatcher<S> implements RequestDispatcher {
     }
 
     @Override
+    @SuppressFBWarnings(value = "REQUESTDISPATCHER_FILE_DISCLOSURE", justification = "Forwarding the request to be handled correctly.")
     public void include(ServletRequest request, ServletResponse response) throws ServletException, IOException {
         forward(request, response);
     }

--- a/core/src/main/java/org/kohsuke/stapler/SingleLinkedList.java
+++ b/core/src/main/java/org/kohsuke/stapler/SingleLinkedList.java
@@ -2,6 +2,7 @@ package org.kohsuke.stapler;
 
 import java.util.AbstractList;
 import java.util.Iterator;
+import java.util.NoSuchElementException;
 
 /**
  * Single linked list which allows sharing of the suffix.
@@ -35,6 +36,9 @@ public class SingleLinkedList<T> extends AbstractList<T> {
             }
 
             public T next() {
+                if (!hasNext()) {
+                    throw new NoSuchElementException();
+                }
                 T r = next.head;
                 next = next.tail;
                 return r;

--- a/core/src/main/java/org/kohsuke/stapler/Stapler.java
+++ b/core/src/main/java/org/kohsuke/stapler/Stapler.java
@@ -98,7 +98,7 @@ public class Stapler extends HttpServlet {
 
     private /*final*/ ServletContext context;
 
-    @SuppressFBWarnings(value = "SE_BAD_FIELD", justification = "A valid issue, but complicated to fix now. Not causing any observable problems.")
+    @SuppressFBWarnings(value = "SE_BAD_FIELD", justification = "The Stapler class is not expected to be serialized.")
     private /*final*/ WebApp webApp;
 
     /**
@@ -395,7 +395,7 @@ public class Stapler extends HttpServlet {
         abstract URL map(String path) throws IOException;
     }
 
-    @SuppressFBWarnings(value = "SE_BAD_FIELD", justification = "A valid issue, but complicated to fix now. Not causing any observable problems.")
+    @SuppressFBWarnings(value = "SE_BAD_FIELD", justification = "The Stapler class is not expected to be serialized.")
     private final LocaleDrivenResourceSelector resourcePathLocaleSelector = new LocaleDrivenResourceSelector() {
         @Override
         URL map(String path) throws IOException {
@@ -418,7 +418,7 @@ public class Stapler extends HttpServlet {
     /**
      * {@link LocaleDrivenResourceSelector} that uses a complete URL as 'path'
      */
-    @SuppressFBWarnings(value = "SE_BAD_FIELD", justification = "A valid issue, but complicated to fix now. Not causing any observable problems.")
+    @SuppressFBWarnings(value = "SE_BAD_FIELD", justification = "The Stapler class is not expected to be serialized.")
     private final LocaleDrivenResourceSelector urlLocaleSelector = new LocaleDrivenResourceSelector() {
         @Override
         URL map(String url) throws IOException {

--- a/core/src/main/java/org/kohsuke/stapler/Stapler.java
+++ b/core/src/main/java/org/kohsuke/stapler/Stapler.java
@@ -319,6 +319,8 @@ public class Stapler extends HttpServlet {
 
         @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Protected by checks at other layers.")
         private long determineLastModified(URL jarURL) {
+            // TODO Fix this so that it works correctly. Needs to handle metacharacters
+            // Windows UNC, etc. Should use URL.toURI, Paths.get(URI), and Files.getLastModifiedTime.
             return new File(jarURL.getFile()).lastModified();
         }
     }
@@ -661,6 +663,7 @@ public class Stapler extends HttpServlet {
      */
     @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Protected by checks at other layers.")
     /*package for test*/ File toFile(URL url) {
+        // TODO Fix this so that it works correctly. Should use URI and Path.
         String urlstr = url.toExternalForm();
         if(!urlstr.startsWith("file:"))
             return null;

--- a/core/src/main/java/org/kohsuke/stapler/Stapler.java
+++ b/core/src/main/java/org/kohsuke/stapler/Stapler.java
@@ -23,6 +23,7 @@
 
 package org.kohsuke.stapler;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import net.sf.json.JSONObject;
 import org.apache.commons.beanutils.ConversionException;
 import org.apache.commons.beanutils.ConvertUtils;
@@ -574,9 +575,9 @@ public class Stapler extends HttpServlet {
                     range = range.substring(6);
                     Matcher m = RANGE_SPEC.matcher(range);
                     if(m.matches()) {
-                        long s = Long.valueOf(m.group(1));
+                        long s = Long.parseLong(m.group(1));
                         long e = m.group(2).length()>0
-                                ? Long.valueOf(m.group(2))+1 //range set is inclusive
+                                ? Long.parseLong(m.group(2))+1 //range set is inclusive
                                 : contentLength; // unspecified value means "all the way to the end"
                         e = Math.min(e,contentLength);
 
@@ -719,8 +720,7 @@ public class Stapler extends HttpServlet {
             }
         }
 
-        // adds this node to ancestor list
-        AncestorImpl a = new AncestorImpl(req, node);
+        addToAncestorList(req, node);
 
         // try overrides
         if (node instanceof StaplerOverridable) {
@@ -818,6 +818,12 @@ public class Stapler extends HttpServlet {
         }
 
         return false;
+    }
+
+    @SuppressFBWarnings(value = "DLS_DEAD_LOCAL_STORE", justification = "Changes state.")
+    private void addToAncestorList(RequestImpl req, Object node) {
+        // adds this node to ancestor list
+        AncestorImpl a = new AncestorImpl(req, node);
     }
 
     /**

--- a/core/src/main/java/org/kohsuke/stapler/Stapler.java
+++ b/core/src/main/java/org/kohsuke/stapler/Stapler.java
@@ -734,7 +734,9 @@ public class Stapler extends HttpServlet {
             }
         }
 
-        addToAncestorList(req, node);
+        // adds this node to ancestor list
+        AncestorImpl ancestor = new AncestorImpl(req, node);
+        ancestor.addToOwner();
 
         // try overrides
         if (node instanceof StaplerOverridable) {
@@ -832,12 +834,6 @@ public class Stapler extends HttpServlet {
         }
 
         return false;
-    }
-
-    @SuppressFBWarnings(value = "DLS_DEAD_LOCAL_STORE", justification = "Changes state.")
-    private void addToAncestorList(RequestImpl req, Object node) {
-        // adds this node to ancestor list
-        AncestorImpl a = new AncestorImpl(req, node);
     }
 
     /**

--- a/core/src/main/java/org/kohsuke/stapler/TearOffSupport.java
+++ b/core/src/main/java/org/kohsuke/stapler/TearOffSupport.java
@@ -26,6 +26,7 @@ package org.kohsuke.stapler;
 import java.lang.reflect.InvocationTargetException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Allows "tear-off" objects to be linked to the parent object.
@@ -37,12 +38,10 @@ import java.util.Map;
  * @author Kohsuke Kawaguchi
  */
 public abstract class TearOffSupport {
-    private volatile Map<Class,Object> tearOffs;
+    private volatile Map<Class,Object> tearOffs = new ConcurrentHashMap<>();
 
     public final <T> T getTearOff(Class<T> t) {
-        Map<Class,Object> m = tearOffs;
-        if(m==null)     return null;
-        return (T)m.get(t);
+        return (T)tearOffs.get(t);
     }
 
     public final <T> T loadTearOff(Class<T> t) {
@@ -69,10 +68,7 @@ public abstract class TearOffSupport {
         return o;
     }
 
-    public synchronized <T> void setTearOff(Class<T> type, T instance) {
-        Map<Class,Object> m = tearOffs;
-        Map<Class,Object> r = m!=null ? new HashMap<Class, Object>(tearOffs) : new HashMap<Class,Object>();
-        r.put(type,instance);
-        tearOffs = r;
+    public <T> void setTearOff(Class<T> type, T instance) {
+        tearOffs.put(type,instance);
     }
 }

--- a/core/src/main/java/org/kohsuke/stapler/TokenList.java
+++ b/core/src/main/java/org/kohsuke/stapler/TokenList.java
@@ -100,7 +100,7 @@ public final class TokenList {
         if(p == null) {
             throw new NumberFormatException();  // no more token
         }
-        long asLongValue = Long.valueOf(p);
+        long asLongValue = Long.parseLong(p);
         idx++;
         return asLongValue;
     }

--- a/core/src/main/java/org/kohsuke/stapler/bind/BoundObjectTable.java
+++ b/core/src/main/java/org/kohsuke/stapler/bind/BoundObjectTable.java
@@ -171,6 +171,7 @@ public class BoundObjectTable implements StaplerFallback {
             return v;
         }
 
+        @SuppressFBWarnings(value = "IS2_INCONSISTENT_SYNC", justification = "This usage does not create synchronization problems.")
         public HttpResponse doEnableLogging() {
             if (DEBUG_LOGGING) {
                 this.logging = true;

--- a/core/src/main/java/org/kohsuke/stapler/bind/BoundObjectTable.java
+++ b/core/src/main/java/org/kohsuke/stapler/bind/BoundObjectTable.java
@@ -23,6 +23,7 @@
 
 package org.kohsuke.stapler.bind;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.HttpResponse;
 import org.kohsuke.stapler.HttpResponses;
@@ -239,6 +240,7 @@ public class BoundObjectTable implements StaplerFallback {
     /**
      * True to activate debug logging of session fragments.
      */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Legacy switch.")
     public static boolean DEBUG_LOGGING = Boolean.getBoolean(BoundObjectTable.class.getName()+".debugLog");
 
     private static final Logger LOGGER = Logger.getLogger(BoundObjectTable.class.getName());

--- a/core/src/main/java/org/kohsuke/stapler/compression/CompressionFilter.java
+++ b/core/src/main/java/org/kohsuke/stapler/compression/CompressionFilter.java
@@ -1,5 +1,7 @@
 package org.kohsuke.stapler.compression;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -117,5 +119,6 @@ public class CompressionFilter implements Filter {
      * Despite its name, this flag does <strong>not</strong> disable {@link CompressionFilter} itself!
      * Rather use {@code DefaultScriptInvoker.COMPRESS_BY_DEFAULT}.
      */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Legacy switch.")
     public static boolean DISABLED = Boolean.getBoolean(CompressionFilter.class.getName()+".disabled");
 }

--- a/core/src/main/java/org/kohsuke/stapler/compression/UncaughtExceptionHandler.java
+++ b/core/src/main/java/org/kohsuke/stapler/compression/UncaughtExceptionHandler.java
@@ -1,5 +1,6 @@
 package org.kohsuke.stapler.compression;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.kohsuke.stapler.AttributeKey;
 
 import javax.servlet.ServletContext;
@@ -31,6 +32,7 @@ public interface UncaughtExceptionHandler {
 
 
     UncaughtExceptionHandler DEFAULT = new UncaughtExceptionHandler() {
+        @SuppressFBWarnings(value = "XSS_SERVLET", justification = "Covered by the escape() method.")
         public void reportException(Throwable e, ServletContext context, HttpServletRequest req, HttpServletResponse rsp) throws ServletException, IOException {
             StringWriter sw = new StringWriter();
             PrintWriter pw = new PrintWriter(sw);

--- a/core/src/main/java/org/kohsuke/stapler/config/ConfigurationLoader.java
+++ b/core/src/main/java/org/kohsuke/stapler/config/ConfigurationLoader.java
@@ -81,12 +81,7 @@ public class ConfigurationLoader {
      * Loads the configuration from the specified {@link Properties} object.
      */
     public static ConfigurationLoader from(final Properties props) throws IOException {
-        return new ConfigurationLoader(new Function<String, String>() {
-            @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE", justification = "False positive. I don't know what spotbugs is doing here.")
-            public String apply(String from) {
-                return props.getProperty(from);
-            }
-        });
+        return new ConfigurationLoader(from -> props.getProperty(from));
     }
 
     public static ConfigurationLoader from(final Map<String,String> props) throws IOException {

--- a/core/src/main/java/org/kohsuke/stapler/config/ConfigurationLoader.java
+++ b/core/src/main/java/org/kohsuke/stapler/config/ConfigurationLoader.java
@@ -4,6 +4,8 @@ import com.google.common.base.Function;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.beanutils.ConvertUtils;
 
 import java.beans.Introspector;
@@ -80,6 +82,7 @@ public class ConfigurationLoader {
      */
     public static ConfigurationLoader from(final Properties props) throws IOException {
         return new ConfigurationLoader(new Function<String, String>() {
+            @SuppressFBWarnings(value = "NP_PARAMETER_MUST_BE_NONNULL_BUT_MARKED_AS_NULLABLE", justification = "False positive. I don't know what spotbugs is doing here.")
             public String apply(String from) {
                 return props.getProperty(from);
             }

--- a/core/src/main/java/org/kohsuke/stapler/framework/AbstractWebAppMain.java
+++ b/core/src/main/java/org/kohsuke/stapler/framework/AbstractWebAppMain.java
@@ -37,6 +37,8 @@ import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.Locale;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
@@ -178,9 +180,10 @@ public abstract class AbstractWebAppMain<T> implements ServletContextListener {
      */
     protected boolean checkEnvironment() {
         home = getHomeDir().getAbsoluteFile();
-        boolean success = home.mkdirs();
-        if (!success) {
-            LOGGER.warning("Failed to create home directory: " + home);
+        try {
+            Files.createDirectories(home.toPath());
+        } catch (IOException ioe) {
+            LOGGER.log(Level.WARNING, "Failed to create home directory: " + home, ioe);
             return false;
         }
         LOGGER.info(getApplicationName()+" home directory: "+home);

--- a/core/src/main/java/org/kohsuke/stapler/framework/AbstractWebAppMain.java
+++ b/core/src/main/java/org/kohsuke/stapler/framework/AbstractWebAppMain.java
@@ -24,6 +24,7 @@
 package org.kohsuke.stapler.framework;
 
 import com.google.common.util.concurrent.SettableFuture;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jvnet.localizer.LocaleProvider;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.Stapler;
@@ -177,7 +178,11 @@ public abstract class AbstractWebAppMain<T> implements ServletContextListener {
      */
     protected boolean checkEnvironment() {
         home = getHomeDir().getAbsoluteFile();
-        home.mkdirs();
+        boolean success = home.mkdirs();
+        if (!success) {
+            LOGGER.warning("Failed to create home directory: " + home);
+            return false;
+        }
         LOGGER.info(getApplicationName()+" home directory: "+home);
 
         // check that home exists (as mkdirs could have failed silently), otherwise throw a meaningful error
@@ -212,6 +217,7 @@ public abstract class AbstractWebAppMain<T> implements ServletContextListener {
      * People makes configuration mistakes, so we are trying to be nice
      * with those by doing {@link String#trim()}.
      */
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Home dir is configured by admin or app.")
     protected File getHomeDir() {
         // check JNDI for the home directory first
         String varName = getApplicationName().toUpperCase() + "_HOME";
@@ -248,6 +254,7 @@ public abstract class AbstractWebAppMain<T> implements ServletContextListener {
      *
      * Override this method to change that behavior.
      */
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Home dir is configured by admin or app.")
     protected File getDefaultHomeDir() {
         return new File(new File(System.getProperty("user.home")),'.'+getApplicationName().toLowerCase());
     }

--- a/core/src/main/java/org/kohsuke/stapler/framework/io/AtomicFileWriter.java
+++ b/core/src/main/java/org/kohsuke/stapler/framework/io/AtomicFileWriter.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.BufferedWriter;
 import java.io.OutputStreamWriter;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 
 /**

--- a/core/src/main/java/org/kohsuke/stapler/framework/io/AtomicFileWriter.java
+++ b/core/src/main/java/org/kohsuke/stapler/framework/io/AtomicFileWriter.java
@@ -23,6 +23,8 @@
 
 package org.kohsuke.stapler.framework.io;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.FileWriter;
 import java.io.Writer;
 import java.io.File;
@@ -47,6 +49,7 @@ public class AtomicFileWriter extends Writer {
     private final File tmpFile;
     private final File destFile;
 
+    @SuppressFBWarnings(value = "PATH_TRAVERSAL_IN", justification = "Protected by checks at other layers.")
     public AtomicFileWriter(File f) throws IOException {
         tmpFile = File.createTempFile("atomic",null,f.getParentFile());
         destFile = f;
@@ -82,7 +85,10 @@ public class AtomicFileWriter extends Writer {
         close();
         if(destFile.exists() && !destFile.delete())
             throw new IOException("Unable to delete "+destFile);
-        tmpFile.renameTo(destFile);
+        boolean success = tmpFile.renameTo(destFile);
+        if (!success) {
+            throw new IOException("Unable to rename: " + destFile);
+        }
     }
 
     /**

--- a/core/src/main/java/org/kohsuke/stapler/framework/io/AtomicFileWriter.java
+++ b/core/src/main/java/org/kohsuke/stapler/framework/io/AtomicFileWriter.java
@@ -84,9 +84,11 @@ public class AtomicFileWriter extends Writer {
 
     public void commit() throws IOException {
         close();
-        if(destFile.exists() && !destFile.delete())
-            throw new IOException("Unable to delete "+destFile);
-        Files.move(tmpFile.toPath(), destFile.toPath());
+        Path destFilePath = destFile.toPath();
+        if (Files.exists(destFilePath)) {
+            Files.delete(destFilePath);
+        }
+        Files.move(tmpFile.toPath(), destFilePath);
     }
 
     /**

--- a/core/src/main/java/org/kohsuke/stapler/framework/io/AtomicFileWriter.java
+++ b/core/src/main/java/org/kohsuke/stapler/framework/io/AtomicFileWriter.java
@@ -86,10 +86,7 @@ public class AtomicFileWriter extends Writer {
         close();
         if(destFile.exists() && !destFile.delete())
             throw new IOException("Unable to delete "+destFile);
-        boolean success = tmpFile.renameTo(destFile);
-        if (!success) {
-            throw new IOException("Unable to rename: " + destFile);
-        }
+        Files.move(tmpFile.toPath(), destFile.toPath());
     }
 
     /**

--- a/core/src/main/java/org/kohsuke/stapler/framework/io/ByteBuffer.java
+++ b/core/src/main/java/org/kohsuke/stapler/framework/io/ByteBuffer.java
@@ -23,6 +23,8 @@
 
 package org.kohsuke.stapler.framework.io;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.ByteArrayOutputStream;
 import java.io.OutputStream;
 import java.io.IOException;
@@ -69,6 +71,7 @@ public class ByteBuffer extends OutputStream {
         this.buf = n;
     }
 
+    @SuppressFBWarnings(value = "DM_DEFAULT_ENCODING", justification = "Legacy behavior.")
     public synchronized String toString() {
         return new String(buf,0,size);
     }

--- a/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/GroovierJellyScript.java
+++ b/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/GroovierJellyScript.java
@@ -23,6 +23,7 @@
 
 package org.kohsuke.stapler.jelly.groovy;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.jelly.JellyContext;
 import org.apache.commons.jelly.JellyTagException;
 import org.apache.commons.jelly.Script;

--- a/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/GroovierJellyScript.java
+++ b/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/GroovierJellyScript.java
@@ -23,7 +23,6 @@
 
 package org.kohsuke.stapler.jelly.groovy;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.jelly.JellyContext;
 import org.apache.commons.jelly.JellyTagException;
 import org.apache.commons.jelly.Script;

--- a/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/JellyBuilder.java
+++ b/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/JellyBuilder.java
@@ -81,11 +81,6 @@ public final class JellyBuilder extends GroovyObjectSupport {
      */
     private XMLOutput output;
 
-    /**
-     * Current {@link Tag} in which we are executing.
-     */
-    private Tag current;
-
     private JellyContext context;
 
     private final Map<Class,GroovyClosureScript> taglibs = new HashMap<Class,GroovyClosureScript>();

--- a/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/SimpleTemplateParser.java
+++ b/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/SimpleTemplateParser.java
@@ -15,6 +15,8 @@
  */
 package org.kohsuke.stapler.jelly.groovy;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -26,6 +28,7 @@ import java.net.URL;
  * @author Kohsuke Kawaguchi
  */
 class SimpleTemplateParser {
+    @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Not relevant in this situation.")
     protected String parse(URL res) throws IOException {
         return parse(new InputStreamReader(res.openStream(),"UTF-8"));
     }

--- a/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/StaplerClosureScript.java
+++ b/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/StaplerClosureScript.java
@@ -1,5 +1,6 @@
 package org.kohsuke.stapler.jelly.groovy;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jvnet.localizer.LocaleProvider;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.jelly.ResourceBundle;
@@ -9,6 +10,7 @@ import java.net.URL;
 /**
  * @author Kohsuke Kawaguchi
  */
+@SuppressFBWarnings(value = "IS2_INCONSISTENT_SYNC", justification = "The synchronization here doesn't make sense, but it's not causing problems.")
 public abstract class StaplerClosureScript extends GroovyClosureScript {
     /**
      * Where was this script loaded from?

--- a/jelly/src/main/java/org/kohsuke/stapler/framework/adjunct/AdjunctManager.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/framework/adjunct/AdjunctManager.java
@@ -163,7 +163,7 @@ public class AdjunctManager {
                 return;
             }
             // remember URLs that we can serve. but don't remember error ones, as it might be unbounded
-            allowedResources.put(path,path);
+            allowedResources.putIfAbsent(path,path);
         }
 
         URL res = classLoader.getResource(path);

--- a/jelly/src/main/java/org/kohsuke/stapler/framework/adjunct/AdjunctManager.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/framework/adjunct/AdjunctManager.java
@@ -32,6 +32,7 @@ import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
 import java.io.IOException;
 import java.net.URL;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
 
 /**
  * This application-scoped object that exposes djuncts to URL.
@@ -75,7 +76,7 @@ public class AdjunctManager {
     /**
      * Map used as a set to remember which resources can be served.
      */
-    private final ConcurrentHashMap<String,String> allowedResources = new ConcurrentHashMap<String,String>();
+    private final ConcurrentSkipListSet<String> allowedResources = new ConcurrentSkipListSet<>();
 
     private final ClassLoader classLoader;
 
@@ -157,13 +158,13 @@ public class AdjunctManager {
         String path = req.getRestOfPath();
         if (path.charAt(0)=='/') path = path.substring(1);
 
-        if(!allowedResources.containsKey(path)) {
+        if(!allowedResources.contains(path)) {
             if(!allowResourceToBeServed(path)) {
                 rsp.sendError(SC_FORBIDDEN);
                 return;
             }
             // remember URLs that we can serve. but don't remember error ones, as it might be unbounded
-            allowedResources.putIfAbsent(path,path);
+            allowedResources.add(path);
         }
 
         URL res = classLoader.getResource(path);

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/CopyStreamTag.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/CopyStreamTag.java
@@ -59,6 +59,7 @@ public class CopyStreamTag extends AbstractStaplerTag {
         this.in = new FileReader(f);
     }
 
+    @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Not relevant in this situation.")
     public void setUrl(URL url) throws IOException {
         setInputStream(url.openStream());
     }
@@ -80,17 +81,14 @@ public class CopyStreamTag extends AbstractStaplerTag {
                     int last = 0;
                     for (int i=0; i<len; i++ ) {
                         char ch = buf[i];
-                        switch(ch) {
-                        case '<':
-                            xmlOutput.characters(buf,last,i-last); // flush
-                            xmlOutput.characters(CHARS_LE,0,CHARS_LE.length);
-                            last = i+1;
-                            break;
-                        case '&':
+                        if (ch == '<') {
+                            xmlOutput.characters(buf, last, i - last); // flush
+                            xmlOutput.characters(CHARS_LE, 0, CHARS_LE.length);
+                            last = i + 1;
+                        } else if (ch == '&') {
                             xmlOutput.characters(buf,last,i-last); // flush
                             xmlOutput.characters(CHARS_AMP,0,CHARS_AMP.length);
                             last = i+1;
-                            break;
                         }
                     }
                     xmlOutput.characters(buf,last,len-last);

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/CopyStreamTag.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/CopyStreamTag.java
@@ -30,6 +30,7 @@ import org.xml.sax.SAXException;
 import org.jvnet.maven.jellydoc.annotation.NoContent;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
 import java.io.IOException;
@@ -37,13 +38,13 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Copies a stream as text.
  * @author Kohsuke Kawaguchi
  */
 @NoContent
-@SuppressFBWarnings(value = "DM_DEFAULT_ENCODING", justification = "Legacy implementation copies stream with default encoding.")
 public class CopyStreamTag extends AbstractStaplerTag {
     private Reader in;
 
@@ -52,11 +53,11 @@ public class CopyStreamTag extends AbstractStaplerTag {
     }
 
     public void setInputStream(InputStream in) {
-        this.in = new InputStreamReader(in);
+        this.in = new InputStreamReader(in, StandardCharsets.UTF_8);
     }
 
     public void setFile(File f) throws FileNotFoundException {
-        this.in = new FileReader(f);
+        this.in = new InputStreamReader(new FileInputStream(f), StandardCharsets.UTF_8);
     }
 
     @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Not relevant in this situation.")

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/CopyStreamTag.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/CopyStreamTag.java
@@ -23,6 +23,7 @@
 
 package org.kohsuke.stapler.jelly;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.jelly.JellyTagException;
 import org.apache.commons.jelly.XMLOutput;
 import org.xml.sax.SAXException;
@@ -42,6 +43,7 @@ import java.net.URL;
  * @author Kohsuke Kawaguchi
  */
 @NoContent
+@SuppressFBWarnings(value = "DM_DEFAULT_ENCODING", justification = "Legacy implementation copies stream with default encoding.")
 public class CopyStreamTag extends AbstractStaplerTag {
     private Reader in;
 

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/DefaultScriptInvoker.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/DefaultScriptInvoker.java
@@ -91,7 +91,7 @@ public class DefaultScriptInvoker implements ScriptInvoker, XMLOutputFactory {
         @Nonnull OutputStream get() throws IOException;
     }
 
-    private class LazyOutputStreamSupplier implements OutputStreamSupplier {
+    private static class LazyOutputStreamSupplier implements OutputStreamSupplier {
         private final OutputStreamSupplier supplier;
         private volatile OutputStream out;
 

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/DefaultScriptInvoker.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/DefaultScriptInvoker.java
@@ -23,6 +23,7 @@
 
 package org.kohsuke.stapler.jelly;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.jelly.JellyContext;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
@@ -202,5 +203,6 @@ public class DefaultScriptInvoker implements ScriptInvoker, XMLOutputFactory {
      *
      * @see <a href="http://www.slideshare.net/guest22d4179/latency-trumps-all">Latency Trumps All</a>
      */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Legacy switch.")
     public static boolean COMPRESS_BY_DEFAULT = Boolean.parseBoolean(System.getProperty(DefaultScriptInvoker.class.getName()+".compress","true"));
 }

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/InternationalizedStringExpression.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/InternationalizedStringExpression.java
@@ -23,6 +23,7 @@
 
 package org.kohsuke.stapler.jelly;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.jelly.expression.Expression;
 import org.apache.commons.jelly.expression.ExpressionSupport;
 import org.apache.commons.jelly.JellyException;
@@ -95,6 +96,7 @@ public class InternationalizedStringExpression extends ExpressionSupport {
      * Note: this code is also copied into idea-stapler-plugin,
      * so don't forget to update that when this code changes.
      */
+    @SuppressFBWarnings(value = "SF_SWITCH_NO_DEFAULT", justification = "No default needed.")
     private String tokenize(String text) throws JellyException {
         int parenthesis=0;
         for(int idx=0;idx<text.length();idx++) {

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyClassLoaderTearOff.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyClassLoaderTearOff.java
@@ -26,7 +26,6 @@ package org.kohsuke.stapler.jelly;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.jelly.JellyContext;
 import org.apache.commons.jelly.JellyException;
 import org.apache.commons.jelly.TagLibrary;
@@ -50,8 +49,7 @@ public class JellyClassLoaderTearOff {
      */
     private volatile WeakReference<LoadingCache<String,TagLibrary>> taglibs;
 
-    @SuppressFBWarnings(value = "MS_PKGPROTECT", justification = "Part of the API, but we could investigate whether it's actually used.")
-    public static ExpressionFactory EXPRESSION_FACTORY = new JexlExpressionFactory();
+    static ExpressionFactory EXPRESSION_FACTORY = new JexlExpressionFactory();
 
     public JellyClassLoaderTearOff(MetaClassLoader owner) {
         this.owner = owner;

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyClassLoaderTearOff.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyClassLoaderTearOff.java
@@ -26,6 +26,7 @@ package org.kohsuke.stapler.jelly;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.jelly.JellyContext;
 import org.apache.commons.jelly.JellyException;
 import org.apache.commons.jelly.TagLibrary;
@@ -49,6 +50,7 @@ public class JellyClassLoaderTearOff {
      */
     private volatile WeakReference<LoadingCache<String,TagLibrary>> taglibs;
 
+    @SuppressFBWarnings(value = "MS_PKGPROTECT", justification = "Part of the API, but we could investigate whether it's actually used.")
     public static ExpressionFactory EXPRESSION_FACTORY = new JexlExpressionFactory();
 
     public JellyClassLoaderTearOff(MetaClassLoader owner) {

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyFacet.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyFacet.java
@@ -23,6 +23,7 @@
 
 package org.kohsuke.stapler.jelly;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.jelly.JellyException;
 import org.apache.commons.jelly.expression.ExpressionFactory;
 import org.kohsuke.MetaInfServices;
@@ -122,6 +123,7 @@ public class JellyFacet extends Facet implements JellyCompatibleFacet {
      * This flag will activate the Jelly evaluation trace.
      * It generates extra comments into HTML, indicating where the fragment was rendered.
      */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Legacy switch.")
     public static boolean TRACE = Boolean.getBoolean("stapler.jelly.trace");
 
     private static final Set<Class<JellyClassTearOff>> TEAROFF_TYPES = Collections.singleton(JellyClassTearOff.class);

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyRequestDispatcher.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyRequestDispatcher.java
@@ -23,6 +23,7 @@
 
 package org.kohsuke.stapler.jelly;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.jelly.JellyTagException;
 import org.apache.commons.jelly.Script;
 import org.kohsuke.stapler.MetaClass;
@@ -61,6 +62,7 @@ public final class JellyRequestDispatcher implements RequestDispatcher {
         }
     }
 
+    @SuppressFBWarnings(value = "REQUESTDISPATCHER_FILE_DISCLOSURE", justification = "Forwarding the request to be handled correctly.")
     public void include(ServletRequest servletRequest, ServletResponse servletResponse) throws ServletException, IOException {
         forward(servletRequest,servletResponse);
     }

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/ReallyStaticTagLibrary.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/ReallyStaticTagLibrary.java
@@ -23,6 +23,7 @@
 
 package org.kohsuke.stapler.jelly;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.jelly.JellyContext;
 import org.apache.commons.jelly.JellyException;
 import org.apache.commons.jelly.JellyTagException;
@@ -142,6 +143,7 @@ public class ReallyStaticTagLibrary extends TagLibrary {
     /**
      * If true, emit the location information.
      */
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Legacy switch.")
     public static boolean EMIT_LOCATION = false;
 
     private static final String[] SUFFIX = {"src/main/resources/","src/test/resources/"};

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/ResourceBundle.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/ResourceBundle.java
@@ -23,6 +23,7 @@
 
 package org.kohsuke.stapler.jelly;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.kohsuke.stapler.MetaClass;
 import org.kohsuke.stapler.WebApp;
 
@@ -145,7 +146,7 @@ public class ResourceBundle {
         String url = baseName + key + ".properties";
         InputStream in=null;
         try {
-            in = new URL(url).openStream();
+            in = openStream(url);
             // an user reported that on IBM JDK, URL.openStream
             // returns null instead of IOException.
             // see http://www.nabble.com/WAS---Hudson-tt16026561.html
@@ -167,6 +168,11 @@ public class ResourceBundle {
 
         resources.put(key,wrapUp(key.length()>0 ? key.substring(1) : "",props));
         return props;
+    }
+
+    @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Not relevant in this situation.")
+    private InputStream openStream(String url) throws IOException {
+        return new URL(url).openStream();
     }
 
     /**

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/ResourceBundle.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/ResourceBundle.java
@@ -171,7 +171,7 @@ public class ResourceBundle {
     }
 
     @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Not relevant in this situation.")
-    private InputStream openStream(String url) throws IOException {
+    private static InputStream openStream(String url) throws IOException {
         return new URL(url).openStream();
     }
 

--- a/jruby/src/main/java/org/kohsuke/stapler/jelly/jruby/RubyTemplateContainer.java
+++ b/jruby/src/main/java/org/kohsuke/stapler/jelly/jruby/RubyTemplateContainer.java
@@ -1,5 +1,6 @@
 package org.kohsuke.stapler.jelly.jruby;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.jelly.Script;
 import org.jruby.RubyClass;
@@ -43,6 +44,7 @@ public class RubyTemplateContainer {
         this.container = container;
     }
 
+    @SuppressFBWarnings(value = "URLCONNECTION_SSRF_FD", justification = "Not relevant in this situation.")
     public Script parseScript(URL path) throws IOException {
         try {
             String template = IOUtils.toString(path.openStream(), "UTF-8");

--- a/jsp/src/main/java/org/kohsuke/stapler/jsp/RequestDispatcherWrapper.java
+++ b/jsp/src/main/java/org/kohsuke/stapler/jsp/RequestDispatcherWrapper.java
@@ -23,6 +23,8 @@
 
 package org.kohsuke.stapler.jsp;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
@@ -43,6 +45,7 @@ final class RequestDispatcherWrapper implements RequestDispatcher {
         this.it = it;
     }
 
+    @SuppressFBWarnings(value = "REQUESTDISPATCHER_FILE_DISCLOSURE", justification = "Forwarding the request to be handled correctly.")
     public void forward(ServletRequest req, ServletResponse rsp) throws ServletException, IOException {
         req.setAttribute("it",it);
         req.setAttribute("staplerRequest",req);
@@ -50,6 +53,7 @@ final class RequestDispatcherWrapper implements RequestDispatcher {
         core.forward(req,rsp);
     }
 
+    @SuppressFBWarnings(value = "REQUESTDISPATCHER_FILE_DISCLOSURE", justification = "Forwarding the request to be handled correctly.")
     public void include(ServletRequest req, ServletResponse rsp) throws ServletException, IOException {
         Object oldIt = push(req, "it", it);
         Object oldRq = push(req, "staplerRequest", req);

--- a/jsp/src/main/java/org/kohsuke/stapler/tags/Include.java
+++ b/jsp/src/main/java/org/kohsuke/stapler/tags/Include.java
@@ -23,6 +23,8 @@
 
 package org.kohsuke.stapler.tags;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
@@ -92,6 +94,7 @@ public class Include extends SimpleTagSupport {
         return getJspContext().getAttribute(name,PageContext.PAGE_SCOPE);
     }
 
+    @SuppressFBWarnings(value = "REQUESTDISPATCHER_FILE_DISCLOSURE", justification = "Forwarding the request to be handled correctly.")
     public void doTag() throws JspException, IOException {
         Object it = getJspContext().getAttribute("it",PageContext.REQUEST_SCOPE);
         final Object oldIt = it;

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
     <!-- It is strongly encouraged to leave it as true. Use false with care only in transient situations. -->
     <spotbugs.failOnError>true</spotbugs.failOnError>
     <!-- Defines a SpotBugs threshold. Use "Low" to discover low-priority bugs.
+         Hint: SpotBugs considers some real NPE risks in Jenkins as low-priority issues, it is recommended to enable it in plugins.
       -->
     <spotbugs.threshold>Medium</spotbugs.threshold>
     <!-- Defines a SpotBugs effort. Use "Max" to maximize the scan depth -->

--- a/pom.xml
+++ b/pom.xml
@@ -93,12 +93,12 @@
     <!-- Defines a SpotBugs threshold. Use "Low" to discover low-priority bugs.
          Hint: SpotBugs considers some real NPE risks in Jenkins as low-priority issues, it is recommended to enable it in plugins.
       -->
-    <spotbugs.threshold>High</spotbugs.threshold>
+    <spotbugs.threshold>Medium</spotbugs.threshold>
     <!-- Defines a SpotBugs effort. Use "Max" to maximize the scan depth -->
     <spotbugs.effort>default</spotbugs.effort>
     <!-- Defines an optional SpotBugs excludes file.
          Generally it is recommended to use @SuppressFBWarnings annotation unless you want to ignore an entire class of issues -->
-    <spotbugs.excludeFilterFile></spotbugs.excludeFilterFile>
+    <spotbugs.excludeFilterFile>${project.basedir}/../src/spotbugs/spotbugs-excludes.xml</spotbugs.excludeFilterFile>
 
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,6 @@
     <!-- It is strongly encouraged to leave it as true. Use false with care only in transient situations. -->
     <spotbugs.failOnError>true</spotbugs.failOnError>
     <!-- Defines a SpotBugs threshold. Use "Low" to discover low-priority bugs.
-         Hint: SpotBugs considers some real NPE risks in Jenkins as low-priority issues, it is recommended to enable it in plugins.
       -->
     <spotbugs.threshold>Medium</spotbugs.threshold>
     <!-- Defines a SpotBugs effort. Use "Max" to maximize the scan depth -->

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,21 @@
     <changelist>-SNAPSHOT</changelist>
     <incrementals.url>https://repo.jenkins-ci.org/incrementals/</incrementals.url>
     <scmTag>HEAD</scmTag>
+
+    <spotbugs-maven-plugin.version>3.1.12</spotbugs-maven-plugin.version>
+    <!-- Whether the build should fail if SpotBugs finds any error. -->
+    <!-- It is strongly encouraged to leave it as true. Use false with care only in transient situations. -->
+    <spotbugs.failOnError>true</spotbugs.failOnError>
+    <!-- Defines a SpotBugs threshold. Use "Low" to discover low-priority bugs.
+         Hint: SpotBugs considers some real NPE risks in Jenkins as low-priority issues, it is recommended to enable it in plugins.
+      -->
+    <spotbugs.threshold>High</spotbugs.threshold>
+    <!-- Defines a SpotBugs effort. Use "Max" to maximize the scan depth -->
+    <spotbugs.effort>default</spotbugs.effort>
+    <!-- Defines an optional SpotBugs excludes file.
+         Generally it is recommended to use @SuppressFBWarnings annotation unless you want to ignore an entire class of issues -->
+    <spotbugs.excludeFilterFile></spotbugs.excludeFilterFile>
+
   </properties>
 
   <build>
@@ -178,6 +193,35 @@
         <artifactId>maven-jellydoc-plugin</artifactId>
         <version>1.2</version>
       </plugin>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <configuration>
+          <failOnError>${spotbugs.failOnError}</failOnError>
+          <xmlOutput>true</xmlOutput>
+          <spotbugsXmlOutput>false</spotbugsXmlOutput>
+          <effort>${spotbugs.effort}</effort>
+          <threshold>${spotbugs.threshold}</threshold>
+          <!-- Empty by default, child POMs are expected to override if needed -->
+          <excludeFilterFile>${spotbugs.excludeFilterFile}</excludeFilterFile>
+          <plugins>
+            <plugin>
+              <groupId>com.h3xstream.findsecbugs</groupId>
+              <artifactId>findsecbugs-plugin</artifactId>
+              <version>1.10.1</version>
+            </plugin>
+          </plugins>
+        </configuration>
+        <executions>
+          <execution>
+            <id>spotbugs</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>verify</phase>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>
@@ -214,6 +258,11 @@
             <generateBackupPoms>false</generateBackupPoms>
             <updateNonincremental>false</updateNonincremental>
           </configuration>
+        </plugin>
+        <plugin>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-maven-plugin</artifactId>
+          <version>${spotbugs-maven-plugin.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -288,6 +337,11 @@
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
       <version>3.2.2</version>
+    </dependency>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs-annotations</artifactId>
+      <version>3.1.12</version>
     </dependency>
   </dependencies>
   </dependencyManagement>

--- a/src/spotbugs/spotbugs-excludes.xml
+++ b/src/spotbugs/spotbugs-excludes.xml
@@ -1,0 +1,10 @@
+<FindBugsFilter>
+  <Match>
+    <!--We don't care about this behavior.-->
+    <Bug pattern="CRLF_INJECTION_LOGS"/>
+  </Match>
+  <Match>
+    <!--Jenkins handles this issue differently or doesn't care about it.-->
+    <Bug pattern="INFORMATION_EXPOSURE_THROUGH_AN_ERROR_MESSAGE"/>
+  </Match>
+</FindBugsFilter>


### PR DESCRIPTION
Add spotbugs and findsecbugs to Stapler as part of the long, ongoing effort to improve static code analysis. Stapler didn't even have standard spotbugs configured so this PR contains findings relating to general items and to security.

I took it to the Medium level (threshold), which seems to be about right for Stapler. This corrects or points out areas that might be of concern but isn't getting too esoteric.

I suppose there could be an argument that it isn't worthwhile to make these improvements in Stapler, because it isn't in active development. But, we sure seem to make a lot of changes to Stapler. I find that having spotbugs helps us to avoid introducing yet more issues, such as further instances of the public, non-final flag. And it brings better awareness to areas that could be an issue or where we need to tread carefully. Therefore, I believe it is better to introduce this analysis to help better support future work.