### PR TITLE
Bump stapler-adjunct-jquery to stop pulling dependency range

### DIFF
--- a/jelly/pom.xml
+++ b/jelly/pom.xml
@@ -74,7 +74,7 @@
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>
       <artifactId>stapler-adjunct-jquery</artifactId>
-      <version>1.8.3-0</version>
+      <version>1.12.4-0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Crazy dependency range that pulls every incremental version: https://github.com/stapler/stapler-adjunct-jquery/blob/stapler-adjunct-jquery-1.8.3-0/pom.xml#L13