### PR TITLE
Update commons-fileupload to match that used in Jenkins

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -107,7 +107,7 @@
       <!-- perhaps mark this dependency optional? -->
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
-      <version>1.2.1</version>
+      <version>1.3.1-jenkins-2</version>
     </dependency>    
     <!-- optional REST support -->
     <dependency>

--- a/core/src/test/java/org/kohsuke/stapler/RequestImplTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/RequestImplTest.java
@@ -60,6 +60,11 @@ public class RequestImplTest {
                 return "UTF-8";
             }
             @Override
+            public String getHeader(String name) {
+                // FILEUPLOAD-195/FILEUPLOAD-228: ignore FileUploadBase.CONTENT_LENGTH
+                return null;
+            }
+            @Override
             public int getContentLength() {
                 return buf.length;
             }


### PR DESCRIPTION
Supersedes #175. See also https://github.com/apache/commons-fileupload/commit/96f8f56556a8592bfed25c82acedeffc4872ac1f + https://github.com/apache/commons-fileupload/commit/b50acb3c1e506a2d7317ee17a7c48b289814de63 + https://github.com/jenkinsci/jenkins/blob/277d725572aa9545062db1b5b9781b33bf9bf7e6/bom/pom.xml#L259

@jeffret-b @jvz et al.