### PR TITLE
Don't use setAccessible, fixes illegal reflective access warnings

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/lang/FieldRef.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/FieldRef.java
@@ -6,6 +6,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 /**
@@ -87,7 +88,7 @@ public abstract class FieldRef extends AnnotatedRef {
                 try {
                     return f.get(instance);
                 } catch (IllegalAccessException e) {
-                    LOGGER.log(Level.WARNING, "please report to the respective component", e);
+                    LOGGER.log(Level.WARNING, "Please report to the respective component", e);
                     f.setAccessible(true);
                     return f.get(instance);
                 }

--- a/core/src/main/java/org/kohsuke/stapler/lang/FieldRef.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/FieldRef.java
@@ -82,7 +82,12 @@ public abstract class FieldRef extends AnnotatedRef {
 
             @Override
             public Object get(Object instance) throws IllegalAccessException {
-                return f.get(instance);
+                try {
+                    return f.get(instance);
+                } catch (IllegalAccessException e) {
+                    f.setAccessible(true);
+                    return f.get(instance);
+                }
             }
 
             @Override

--- a/core/src/main/java/org/kohsuke/stapler/lang/FieldRef.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/FieldRef.java
@@ -69,8 +69,6 @@ public abstract class FieldRef extends AnnotatedRef {
     }
 
     public static FieldRef wrap(final Field f) {
-        f.setAccessible(true);
-
         return new FieldRef() {
             @Override
             public <T extends Annotation> T getAnnotation(Class<T> type) {

--- a/core/src/main/java/org/kohsuke/stapler/lang/FieldRef.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/FieldRef.java
@@ -6,6 +6,8 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
@@ -15,6 +17,8 @@ import java.util.stream.Collectors;
  * @author Kohsuke Kawaguchi
  */
 public abstract class FieldRef extends AnnotatedRef {
+
+    private static final Logger LOGGER = Logger.getLogger(FieldRef.class.getName());
 
     public interface Filter {
         boolean keep(FieldRef m);
@@ -85,6 +89,7 @@ public abstract class FieldRef extends AnnotatedRef {
                 try {
                     return f.get(instance);
                 } catch (IllegalAccessException e) {
+                    LOGGER.warning(e.getMessage() + ", please report to the respective component");
                     f.setAccessible(true);
                     return f.get(instance);
                 }

--- a/core/src/main/java/org/kohsuke/stapler/lang/FieldRef.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/FieldRef.java
@@ -87,7 +87,7 @@ public abstract class FieldRef extends AnnotatedRef {
                 try {
                     return f.get(instance);
                 } catch (IllegalAccessException e) {
-                    LOGGER.warning(e.getMessage() + ", please report to the respective component");
+                    LOGGER.log(Level.WARNING, "please report to the respective component", e);
                     f.setAccessible(true);
                     return f.get(instance);
                 }

--- a/core/src/main/java/org/kohsuke/stapler/lang/FieldRef.java
+++ b/core/src/main/java/org/kohsuke/stapler/lang/FieldRef.java
@@ -6,9 +6,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
-import java.util.logging.Level;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
 
 /**
  * Fields of {@link Klass}.


### PR DESCRIPTION
Some simple testing seems to show this is ok