### PR TITLE
Convert `GString` to `String` when bridging to jelly.

### DIFF
--- a/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/JellyBuilder.java
+++ b/groovy/src/main/java/org/kohsuke/stapler/jelly/groovy/JellyBuilder.java
@@ -24,6 +24,7 @@
 package org.kohsuke.stapler.jelly.groovy;
 
 import groovy.lang.Closure;
+import groovy.lang.GString;
 import groovy.lang.GroovyObjectSupport;
 import groovy.lang.MissingMethodException;
 import groovy.lang.MissingPropertyException;
@@ -322,8 +323,12 @@ public final class JellyBuilder extends GroovyObjectSupport {
                 if (attributes != null) {
                     for (Entry e : attributes.entrySet()) {
                         Object v = e.getValue();
-                        if (v!=null)
+                        if (v != null) {
+                            if (v instanceof GString) {
+                                v = v.toString();
+                            }
                             tagScript.addAttribute(e.getKey().toString(), new ConstantExpression(v));
+                        }
                     }
                 }
 


### PR DESCRIPTION
When using a groovy view and passing a groovy expression as
`"${e1}${e2}"` to a taglib, the resulting value is not coerced to a
String, which can lead to incorrect results when calling functions from
within jelly.

For example, when declaring a widget in Jenkins, using the following `index.groovy` as view

```
def l = namespace(lib.LayoutTagLib);

l.pane(width:2, title:"Title", id:"${my.urlName}", collapsedText:"CollapsedText") {
  text('Foo')
}
```

In the resulting map that is passed to `JellyBuilder`, `id` has type `GStringImpl`, unlike `title` or `collapsedText` which get coerced to `String`.

Then in https://github.com/jenkinsci/jenkins/blob/62546443947fafecc94a5e3b47bb9129bed8e148/core/src/main/resources/lib/layout/pane.jelly#L51, the function call doesn't happen because `attr.id` is a `GString`, not a `String`.

@jglick 