### PR TITLE
@AnyVerb annotation makes web methods explicitly accept any HTTP verb

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/verb/AnyVerb.java
+++ b/core/src/main/java/org/kohsuke/stapler/verb/AnyVerb.java
@@ -1,0 +1,26 @@
+package org.kohsuke.stapler.verb;
+
+import org.kohsuke.stapler.WebMethod;
+import org.kohsuke.stapler.interceptor.InterceptorAnnotation;
+import org.kohsuke.stapler.interceptor.Stage;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Explicitly allows any HTTP verb for {@link WebMethod}. This isn't just a
+ * no-op in case it would be combined with a more restrictive verb, but
+ * conceptually identical to not have any annotation, but friendlier for static
+ * analysis.
+ *
+ */
+@Target(METHOD)
+@Retention(RUNTIME)
+@Documented
+@InterceptorAnnotation(value = HttpVerbInterceptor.class, stage = Stage.SELECTION)
+public @interface AnyVerb {
+}

--- a/core/src/main/java/org/kohsuke/stapler/verb/HttpVerbInterceptor.java
+++ b/core/src/main/java/org/kohsuke/stapler/verb/HttpVerbInterceptor.java
@@ -40,6 +40,7 @@ import java.lang.reflect.InvocationTargetException;
  * @see POST
  * @see PUT
  * @see DELETE
+ * @see AnyVerb
  */
 public class HttpVerbInterceptor extends Interceptor {
     @Override
@@ -57,7 +58,7 @@ public class HttpVerbInterceptor extends Interceptor {
             Class<? extends Annotation> t = a.annotationType();
             InterceptorAnnotation ia = t.getAnnotation(InterceptorAnnotation.class);
             if (ia != null && ia.value() == HttpVerbInterceptor.class) {
-                if (t.getSimpleName().equals(method)) {
+                if (t.getSimpleName().equals(method) || t == AnyVerb.class) {
                     return true;
                 }
             }


### PR DESCRIPTION
I want an explicit version of the implied default. Alternatively, people could use `@GET @POST` on the same method (more verbs we rarely care about).

WIP. Untested.