### PR TITLE
Migrate from com.google.common.base.Function to java.util.function.Function

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/config/ConfigurationLoader.java
+++ b/core/src/main/java/org/kohsuke/stapler/config/ConfigurationLoader.java
@@ -1,6 +1,6 @@
 package org.kohsuke.stapler.config;
 
-import com.google.common.base.Function;
+import java.util.function.Function;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.StandardOpenOption;


### PR DESCRIPTION
Usage of the Guava `com.google.common.base.Function` type was limited to a private field and a private constructor, so we can safely migrate to `java.util.function.Function` without breaking compatibility.