### PR TITLE
Migrate from com.google.common.base.Predicate to java.util.function.Predicate

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/export/FilteringTreePruner.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/FilteringTreePruner.java
@@ -1,6 +1,6 @@
 package org.kohsuke.stapler.export;
 
-import com.google.common.base.Predicate;
+import java.util.function.Predicate;
 
 /**
  * Decorates a base {@link TreePruner} by refusing additional properties
@@ -19,7 +19,7 @@ class FilteringTreePruner extends TreePruner {
 
     @Override
     public TreePruner accept(Object node, Property prop) {
-        if (predicate.apply(prop.name))
+        if (predicate.test(prop.name))
             return null;
         TreePruner child = base.accept(node, prop);
 

--- a/core/src/main/java/org/kohsuke/stapler/export/Model.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Model.java
@@ -40,7 +40,7 @@ import java.util.logging.Logger;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nullable;
 
-import com.google.common.base.Predicate;
+import java.util.function.Predicate;
 import org.kohsuke.stapler.export.TreePruner.ByDepth;
 
 /**
@@ -129,7 +129,7 @@ public class Model<T> {
      */
     /*package*/ final Predicate<String> HAS_PROPERTY_NAME = new Predicate<String>() {
         @Override
-        public boolean apply(@Nullable String name) {
+        public boolean test(@Nullable String name) {
             return propertyNames.contains(name);
         }
     };
@@ -138,7 +138,7 @@ public class Model<T> {
      */
     /*package*/ final Predicate<String> HAS_PROPERTY_NAME_IN_ANCESTRY = new Predicate<String>() {
         @Override
-        public boolean apply(@Nullable String name) {
+        public boolean test(@Nullable String name) {
             for (Model m=Model.this; m!=null; m=m.superModel)
                 if (m.propertyNames.contains(name))
                     return true;


### PR DESCRIPTION
Despite the fact that `com.google.common.base.Predicate` is used in public APIs, it is safe to migrate this to `java.util.function.Predicate`.

### Searching for API usages in sources

The only references in sources are to a copy of Stapler in the `io.jenkins.blueocean.commons.stapler.export` package namespace, apparently added in jenkinsci/blueocean-plugin#711. These references are to a different package and we are not affecting them in this change.

- [`FilteringTreePruner`](https://github.com/search?ref=simplesearch&type=Code&q=user%3Ajenkinsci+%22FilteringTreePruner%22)
- [`HAS_PROPERTY_NAME`](https://github.com/search?ref=simplesearch&type=Code&q=user%3Ajenkinsci+%22HAS_PROPERTY_NAME%22)
- [`HAS_PROPERTY_NAME_IN_ANCESTRY`](https://github.com/search?ref=simplesearch&type=Code&q=user%3Ajenkinsci+%22HAS_PROPERTY_NAME_IN_ANCESTRY%22)

### Searching for API usages in binaries

Creating `/tmp/additionalClasses` with

```
org/kohsuke/stapler/export/FilteringTreePruner
```

and `/tmp/additionalFields` with

```
org.kohsuke.stapler.export.Model#HAS_PROPERTY_NAME
org.kohsuke.stapler.export.Model#HAS_PROPERTY_NAME_IN_ANCESTRY
```

then using `jenkins-infra/usage-in-plugins` to look for usages in plugins, including those in CloudBees CI, with

```bash
mvn process-classes exec:exec -Dexec.executable=java -Dexec.args='-classpath %classpath org.jenkinsci.deprecatedusage.Main --additionalClasses /tmp/additionalClasses --additionalFields /tmp/additionalFields --onlyIncludeSpecified --updateCenter https://jenkins-updates.cloudbees.com/update-center/envelope-core-oc/update-center.json?version=2.263.2.3,https://jenkins-updates.cloudbees.com/update-center/envelope-core-mm/update-center.json?version=2.263.2.3'
```

produced no references.