### PR TITLE
Migrate from com.google.common.util.concurrent.SettableFuture to Java 8 java.util.concurrent.CompletableFuture

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/framework/AbstractWebAppMain.java
+++ b/core/src/main/java/org/kohsuke/stapler/framework/AbstractWebAppMain.java
@@ -23,7 +23,7 @@
 
 package org.kohsuke.stapler.framework;
 
-import com.google.common.util.concurrent.SettableFuture;
+import java.util.concurrent.CompletableFuture;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.jvnet.localizer.LocaleProvider;
 import org.kohsuke.stapler.StaplerRequest;
@@ -68,7 +68,7 @@ public abstract class AbstractWebAppMain<T> implements ServletContextListener {
      */
     protected File home;
 
-    private SettableFuture<Object> initializer = SettableFuture.create();
+    private CompletableFuture<Object> initializer = new CompletableFuture<>();
 
     protected AbstractWebAppMain(Class<T> rootType) {
         this.rootType = rootType;
@@ -137,18 +137,18 @@ public abstract class AbstractWebAppMain<T> implements ServletContextListener {
         try {
             Object app = createApplication();
             context.setAttribute(APP, app);
-            initializer.set(app);
+            initializer.complete(app);
         } catch (Error e) {
             LOGGER.log(Level.SEVERE, "Failed to initialize "+getApplicationName(),e);
-            initializer.setException(e);
+            initializer.completeExceptionally(e);
             throw e;
         } catch (RuntimeException e) {
             LOGGER.log(Level.SEVERE, "Failed to initialize "+getApplicationName(),e);
-            initializer.setException(e);
+            initializer.completeExceptionally(e);
             throw e;
         } catch (Exception e) {
             LOGGER.log(Level.SEVERE, "Failed to initialize "+getApplicationName(),e);
-            initializer.setException(e);
+            initializer.completeExceptionally(e);
             throw new Error(e);
         } finally {
             // in case the above catch clauses miss this.


### PR DESCRIPTION
According to [this guide](https://github.com/krka/java8-future-guide), `SettableFuture.create()` can be replaced with Java 8's `new CompletableFuture()`. I did so in Stapler, then tried to test the change. Unfortunately I could not find any usages of `org.kohsuke.stapler.framework.AbstractWebAppMain` in order to test the change. Jenkins core itself has its own implementation of `ServletContextListener`, `hudson.WebAppMain` (which does not use `org.kohsuke.stapler.framework.AbstractWebAppMain`). On the plus side, if `org.kohsuke.stapler.framework.AbstractWebAppMain` is unused then at least I know I will not be breaking anything by changing it.

### Searching for API usages in sources

The only references to [`AbstractWebAppMain`](https://github.com/search?ref=simplesearch&type=Code&q=user%3Ajenkinsci+%22AbstractWebAppMain%22) in sources are in these three repositories:

- https://github.com/jenkinsci/backend-goto-app
- https://github.com/jenkinsci/backend-jpi-create
- https://github.com/jenkinsci/backend-recipe-submission-app

All of these repositories are archived and read-only.

### Searching for API usages in binaries

Creating `/tmp/additionalClasses` with

```
org/kohsuke/stapler/framework/AbstractWebAppMain
```

then using jenkins-infra/usage-in-plugins to look for usages in plugins, including those in CloudBees CI, with

```
mvn process-classes exec:exec -Dexec.executable=java -Dexec.args='-classpath %classpath org.jenkinsci.deprecatedusage.Main --additionalClasses /tmp/additionalClasses --onlyIncludeSpecified --updateCenter https://jenkins-updates.cloudbees.com/update-center/envelope-core-oc/update-center.json?version=2.263.4.2,https://jenkins-updates.cloudbees.com/update-center/envelope-core-mm/update-center.json?version=2.263.4.2'
```

produced no references.