### PR TITLE
Update to commons-beanutils:1.9.4 without disabling the protection

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>1.9.2</version>
+      <version>1.9.4</version>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/AttributeNameRewritingTagScript.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/AttributeNameRewritingTagScript.java
@@ -18,6 +18,9 @@ import org.apache.commons.jelly.impl.TagScript;
 
     @Override
     public void addAttribute(String name, Expression expression) {
+        if (replacement.equals(name)) {
+            throw new IllegalArgumentException("The attribute '" + replacement + "' cannot be set on this element, set '" + original + "' instead");
+        }
         if (original.equals(name)) {
             super.addAttribute(replacement, expression);
         } else {

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/AttributeNameRewritingTagScript.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/AttributeNameRewritingTagScript.java
@@ -19,7 +19,8 @@ import org.apache.commons.jelly.impl.TagScript;
     @Override
     public void addAttribute(String name, Expression expression) {
         if (replacement.equals(name)) {
-            throw new IllegalArgumentException("The attribute '" + replacement + "' cannot be set on this element, set '" + original + "' instead");
+            // cf. TagScript#run
+            throw new IllegalArgumentException("This tag does not understand the '" + replacement + "' attribute");
         }
         if (original.equals(name)) {
             super.addAttribute(replacement, expression);

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/AttributeNameRewritingTagScript.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/AttributeNameRewritingTagScript.java
@@ -1,0 +1,27 @@
+package org.kohsuke.stapler.jelly;
+
+import org.apache.commons.jelly.expression.Expression;
+import org.apache.commons.jelly.impl.TagScript;
+
+/**
+ * This class implements a {@link TagScript} that allows rewriting attribute names.
+ *
+ */
+/* package */ class AttributeNameRewritingTagScript extends TagScript {
+    private String original;
+    private final String replacement;
+
+    public AttributeNameRewritingTagScript(String original, String replacement) {
+        this.original = original;
+        this.replacement = replacement;
+    }
+
+    @Override
+    public void addAttribute(String name, Expression expression) {
+        if (original.equals(name)) {
+            super.addAttribute(replacement, expression);
+        } else {
+            super.addAttribute(name, expression);
+        }
+    }
+}

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/AttributeNameRewritingTagScript.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/AttributeNameRewritingTagScript.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (c) 2021 CloudBees, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification, are permitted provided
+ * that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright notice, this list of
+ *       conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright notice, this list of
+ *       conditions and the following disclaimer in the documentation and/or other materials
+ *       provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS
+ * OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+ * OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+ * IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+ * THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
 package org.kohsuke.stapler.jelly;
 
 import org.apache.commons.jelly.expression.Expression;

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/AttributeNameRewritingTagScript.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/AttributeNameRewritingTagScript.java
@@ -8,7 +8,7 @@ import org.apache.commons.jelly.impl.TagScript;
  *
  */
 /* package */ class AttributeNameRewritingTagScript extends TagScript {
-    private String original;
+    private final String original;
     private final String replacement;
 
     public AttributeNameRewritingTagScript(String original, String replacement) {

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/CustomJellyContext.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/CustomJellyContext.java
@@ -23,6 +23,9 @@
 
 package org.kohsuke.stapler.jelly;
 
+import org.apache.commons.beanutils.BeanUtilsBean;
+import org.apache.commons.beanutils.PropertyUtilsBean;
+import org.apache.commons.beanutils.SuppressPropertiesBeanIntrospector;
 import org.apache.commons.jelly.parser.XMLParser;
 import org.apache.commons.jelly.expression.ExpressionFactory;
 import org.apache.commons.jelly.expression.Expression;
@@ -81,6 +84,12 @@ class CustomJellyContext extends JellyContext {
         // we achieve substantial performance improvement.
         registerTagLibrary("",ReallyStaticTagLibrary.INSTANCE);
         registerTagLibrary("this",ThisTagLibrary.INSTANCE);
+
+        if (DISABLE_BEANUTILS_CLASS_SUPPRESSION) {
+            /* In case our existing workarounds in StaplerTagLibrary for IncludeTag aren't enough */
+            PropertyUtilsBean propertyUtilsBean = BeanUtilsBean.getInstance().getPropertyUtils();
+            propertyUtilsBean.removeBeanIntrospector(SuppressPropertiesBeanIntrospector.SUPPRESS_CLASS);
+        }
     }
 
     @Override
@@ -108,6 +117,8 @@ class CustomJellyContext extends JellyContext {
     }
 
     public static /* final */ boolean ESCAPE_BY_DEFAULT = Boolean.valueOf(System.getProperty(CustomJellyContext.class.getName() + ".escapeByDefault", "true"));
+
+    private static final boolean DISABLE_BEANUTILS_CLASS_SUPPRESSION = Boolean.getBoolean(CustomJellyContext.class.getName() + ".disableBeanUtilsClassSuppression");
 
     private static class CustomXMLParser extends XMLParser implements ExpressionFactory {
         private ResourceBundle resourceBundle;

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/IncludeTag.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/IncludeTag.java
@@ -23,6 +23,7 @@
 
 package org.kohsuke.stapler.jelly;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.jelly.JellyContext;
 import org.apache.commons.jelly.JellyTagException;
 import org.apache.commons.jelly.Script;
@@ -44,6 +45,9 @@ import java.util.logging.Logger;
  */
 public class IncludeTag extends TagSupport {
     public static final Logger LOGGER = Logger.getLogger(IncludeTag.class.getName());
+
+    @SuppressFBWarnings("MS_SHOULD_BE_FINAL")
+    public static /* non-final for script console */ boolean SKIP_LOGGING_CLASS_SETTER = Boolean.getBoolean(IncludeTag.class.getName() + ".skipLoggingClassSetter");
 
     private Object it;
 
@@ -89,7 +93,8 @@ public class IncludeTag extends TagSupport {
      * problems with new commons-beanutils restrictions via
      * {@code ConvertingWrapDynaBean} use in {@code JellyBuilder}.
      * {@link StaplerTagLibrary} uses {@link AttributeNameRewritingTagScript}
-     * to ensure attempts to set {@code class} instead set {@code clazz}.
+     * to ensure attempts to set {@code class} instead set {@code clazz}, and
+     * that attempts to set {@code clazz} directly that way fail.
      */
     public void setClazz(Class clazz) {
         this.clazz = clazz;
@@ -97,7 +102,9 @@ public class IncludeTag extends TagSupport {
 
     @Deprecated // TODO Remove this method?
     public void setClass(Class clazz) {
-        LOGGER.log(Level.WARNING, "Unexpected call to #setClass", new Exception());
+        if (!SKIP_LOGGING_CLASS_SETTER) {
+            LOGGER.log(Level.WARNING, "Unexpected call to #setClass", new Exception());
+        }
         this.clazz = clazz;
     }
 

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/IncludeTag.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/IncludeTag.java
@@ -88,6 +88,8 @@ public class IncludeTag extends TagSupport {
      * This used to be called {@code setClass}, but that ended up causing
      * problems with new commons-beanutils restrictions via
      * {@code ConvertingWrapDynaBean} use in {@code JellyBuilder}.
+     * {@link StaplerTagLibrary} uses {@link AttributeNameRewritingTagScript}
+     * to ensure attempts to set {@code class} instead set {@code clazz}.
      */
     public void setClazz(Class clazz) {
         this.clazz = clazz;

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/IncludeTag.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/IncludeTag.java
@@ -34,12 +34,17 @@ import org.kohsuke.stapler.WebApp;
 import org.xml.sax.SAXException;
 import org.jvnet.maven.jellydoc.annotation.Required;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /**
  * Tag that includes views of the object.
  *
  * @author Kohsuke Kawaguchi
  */
 public class IncludeTag extends TagSupport {
+    public static final Logger LOGGER = Logger.getLogger(IncludeTag.class.getName());
+
     private Object it;
 
     private String page;
@@ -48,7 +53,7 @@ public class IncludeTag extends TagSupport {
 
     private boolean optional;
 
-    private Class clazz;
+    private Class className;
 
     /**
      * Specifies the name of the JSP to be included.
@@ -79,9 +84,19 @@ public class IncludeTag extends TagSupport {
      *
      * By default this is "from.getClass()". This takes
      * precedence over the {@link #setFrom(Object)} method.
+     *
+     * This used to be called {@code setClass}, but that ended up causing
+     * problems with new commons-beanutils restrictions via
+     * {@code ConvertingWrapDynaBean} use in {@code JellyBuilder}.
      */
+    public void setClassName(Class clazz) {
+        this.className = clazz;
+    }
+
+    @Deprecated // TODO Remove this method?
     public void setClass(Class clazz) {
-        this.clazz = clazz;
+        LOGGER.log(Level.WARNING, "Unexpected call to #setClass", new Exception());
+        this.className = clazz;
     }
 
     /**
@@ -157,7 +172,7 @@ public class IncludeTag extends TagSupport {
     }
 
     private Class getScriptClass(Object it) {
-        if (clazz != null) return clazz;
+        if (className != null) return className;
         if (from != null) return from.getClass();
         else return it.getClass();
     }

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/IncludeTag.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/IncludeTag.java
@@ -53,7 +53,7 @@ public class IncludeTag extends TagSupport {
 
     private boolean optional;
 
-    private Class className;
+    private Class clazz;
 
     /**
      * Specifies the name of the JSP to be included.
@@ -89,14 +89,14 @@ public class IncludeTag extends TagSupport {
      * problems with new commons-beanutils restrictions via
      * {@code ConvertingWrapDynaBean} use in {@code JellyBuilder}.
      */
-    public void setClassName(Class clazz) {
-        this.className = clazz;
+    public void setClazz(Class clazz) {
+        this.clazz = clazz;
     }
 
     @Deprecated // TODO Remove this method?
     public void setClass(Class clazz) {
         LOGGER.log(Level.WARNING, "Unexpected call to #setClass", new Exception());
-        this.className = clazz;
+        this.clazz = clazz;
     }
 
     /**
@@ -172,7 +172,7 @@ public class IncludeTag extends TagSupport {
     }
 
     private Class getScriptClass(Object it) {
-        if (className != null) return className;
+        if (clazz != null) return clazz;
         if (from != null) return from.getClass();
         else return it.getClass();
     }

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/StaplerTagLibrary.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/StaplerTagLibrary.java
@@ -23,6 +23,7 @@
 
 package org.kohsuke.stapler.jelly;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.jelly.JellyContext;
 import org.apache.commons.jelly.JellyException;
 import org.apache.commons.jelly.JellyTagException;
@@ -106,7 +107,7 @@ public class StaplerTagLibrary extends TagLibrary {
                 }
             };
 
-        if (name.equals("include")) {
+        if (!DISABLE_INCLUDE_TAG_CLASS_ATTRIBUTE_REWRITING && name.equals("include")) {
             // Retain backward compatibility with all views setting the obsolete 'class' attribute.
             // See IncludeTag#setClazz for details.
             final AttributeNameRewritingTagScript script = new AttributeNameRewritingTagScript("class", "clazz");
@@ -118,4 +119,8 @@ public class StaplerTagLibrary extends TagLibrary {
     }
 
     private static final String ONCE_TAG_KEY = "stapler.once";
+
+    // Disable the st:include compatibility workaround to allow testing
+    @SuppressFBWarnings(value = "MS_SHOULD_BE_FINAL", justification = "Exposed for tests")
+    public static /* non-final */ boolean DISABLE_INCLUDE_TAG_CLASS_ATTRIBUTE_REWRITING = false;
 }

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/StaplerTagLibrary.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/StaplerTagLibrary.java
@@ -29,6 +29,7 @@ import org.apache.commons.jelly.JellyTagException;
 import org.apache.commons.jelly.Script;
 import org.apache.commons.jelly.TagLibrary;
 import org.apache.commons.jelly.XMLOutput;
+import org.apache.commons.jelly.impl.DefaultTagFactory;
 import org.apache.commons.jelly.impl.TagScript;
 import org.xml.sax.Attributes;
 
@@ -104,6 +105,12 @@ public class StaplerTagLibrary extends TagLibrary {
                         getTagBody().run(context,output);
                 }
             };
+
+        if (name.equals("include")) {
+            final AttributeNameRewritingTagScript script = new AttributeNameRewritingTagScript("class", "className");
+            script.setTagFactory(new DefaultTagFactory(IncludeTag.class));
+            return script;
+        }
 
         return super.createTagScript(name, attributes);
     }

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/StaplerTagLibrary.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/StaplerTagLibrary.java
@@ -107,7 +107,9 @@ public class StaplerTagLibrary extends TagLibrary {
             };
 
         if (name.equals("include")) {
-            final AttributeNameRewritingTagScript script = new AttributeNameRewritingTagScript("class", "className");
+            // Retain backward compatibility with all views setting the obsolete 'class' attribute.
+            // See IncludeTag#setClazz for details.
+            final AttributeNameRewritingTagScript script = new AttributeNameRewritingTagScript("class", "clazz");
             script.setTagFactory(new DefaultTagFactory(IncludeTag.class));
             return script;
         }


### PR DESCRIPTION
This pull request attempts to update to `commons-beanutils:1.9.4` without disabling the additional protection it offers around the `class` attribute.

It seems in my (fairly limited so far) testing that the problem is `st:include`'s `class` attribute. So this pull request renames the attribute to `clazz` (and keeps the existing setter for compatibility).

This PR additionally proposes a workaround that applies when Jelly files are being parsed and the resulting tags are created: For the `st:include` tag, when the `class` attribute would be set, instead set `clazz`. This attempts to take care of all existing code that sets the `class` attribute for this tag.

I am unsure how best to go about ensuring this doesn't cause a lot of problems. While this fix looks fairly safe, it may also be incomplete. In the short term, #209 seems like the safer approach.

CC @basil 