### PR TITLE
Remove Stapler's Guava dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -93,6 +93,11 @@
       <version>11.0.1</version>
     </dependency>
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+      <version>2.9.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.kohsuke</groupId>
       <artifactId>asm5</artifactId>
       <version>5.0.1</version>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -22,6 +22,41 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.2.4</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <artifactSet>
+                <includes>
+                  <include>com.github.ben-manes.caffeine:caffeine</include>
+                </includes>
+              </artifactSet>
+              <relocations>
+                <relocation>
+                  <pattern>com.github.benmanes.caffeine</pattern>
+                  <shadedPattern>org.kohsuke.stapler.shaded.com.github.benmanes.caffeine</shadedPattern>
+                </relocation>
+              </relocations>
+              <filters>
+                <filter>
+                  <artifact>com.github.ben-manes.caffeine:caffeine</artifact>
+                  <excludes>
+                    <exclude>META-INF/**</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -88,11 +88,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>com.google.guava</groupId>
-      <artifactId>guava</artifactId>
-      <version>11.0.1</version>
-    </dependency>
-    <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
       <version>2.9.0</version>

--- a/core/src/main/java/org/kohsuke/stapler/AbstractTearOff.java
+++ b/core/src/main/java/org/kohsuke/stapler/AbstractTearOff.java
@@ -23,8 +23,8 @@
 
 package org.kohsuke.stapler;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 import java.io.File;
@@ -58,7 +58,7 @@ public abstract class AbstractTearOff<CLT,S,E extends Exception> extends Caching
             this.script = script;
         }
     }
-    private final Cache<URL, ExpirableCacheHit<S>> cachedScripts = CacheBuilder.newBuilder().softValues().build();
+    private final Cache<URL, ExpirableCacheHit<S>> cachedScripts = Caffeine.newBuilder().softValues().build();
 
     protected AbstractTearOff(MetaClass owner, Class<CLT> cltClass) {
         this.owner = owner;

--- a/core/src/main/java/org/kohsuke/stapler/CachingScriptLoader.java
+++ b/core/src/main/java/org/kohsuke/stapler/CachingScriptLoader.java
@@ -1,8 +1,8 @@
 package org.kohsuke.stapler;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 
 import java.net.URL;
 
@@ -25,7 +25,7 @@ public abstract class CachingScriptLoader<S, E extends Exception> {
      *
      * {@link Optional} is used as Google Collection doesn't allow null values in a map.
      */
-    private final LoadingCache<String,Optional<S>> scripts = CacheBuilder.newBuilder().softValues().build(new CacheLoader<String, Optional<S>>() {
+    private final LoadingCache<String,Optional<S>> scripts = Caffeine.newBuilder().softValues().build(new CacheLoader<String, Optional<S>>() {
         public Optional<S> load(String from) {
             try {
                 return Optional.create(loadScript(from));
@@ -59,7 +59,7 @@ public abstract class CachingScriptLoader<S, E extends Exception> {
         if (MetaClass.NO_CACHE) 
             return loadScript(name);
         else
-            return scripts.getUnchecked(name).get();
+            return scripts.get(name).get();
     }
 
     /**

--- a/core/src/main/java/org/kohsuke/stapler/Function.java
+++ b/core/src/main/java/org/kohsuke/stapler/Function.java
@@ -23,9 +23,9 @@
 
 package org.kohsuke.stapler;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.CacheLoader;
+import com.github.benmanes.caffeine.cache.LoadingCache;
 import org.apache.commons.lang.StringUtils;
 import org.kohsuke.stapler.interceptor.Interceptor;
 import org.kohsuke.stapler.interceptor.InterceptorAnnotation;
@@ -195,7 +195,7 @@ public abstract class Function {
                 }
 
                 // if the databinding method is provided, call that
-                Function binder = PARSE_METHODS.getUnchecked(t);
+                Function binder = PARSE_METHODS.get(t);
                 if (binder!=RETURN_NULL) {
                     arguments[i] = binder.bindAndInvoke(null,req,rsp);
                     continue;
@@ -226,7 +226,7 @@ public abstract class Function {
             throw new AssertionError(e);    // impossible
         }
 
-        PARSE_METHODS = CacheBuilder.newBuilder().weakKeys().build(new CacheLoader<Class,Function>() {
+        PARSE_METHODS = Caffeine.newBuilder().weakKeys().build(new CacheLoader<Class,Function>() {
             public Function load(Class from) {
                 // MethdFunction for invoking a static method as a static method
                 FunctionList methods = new ClassDescriptor(from).methods.name("fromStapler");

--- a/core/src/main/java/org/kohsuke/stapler/export/Iterators.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Iterators.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2007 The Guava Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.kohsuke.stapler.export;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+/**
+ * This class contains static utility methods that operate on or return objects of type {@link
+ * Iterator}.
+ *
+ * <p><i>Performance notes:</i> Unless otherwise noted, all of the iterators produced in this class
+ * are <i>lazy</i>, which means that they only advance the backing iteration when absolutely
+ * necessary.
+ *
+ * <p>See the Guava User Guide section on <a href=
+ * "https://github.com/google/guava/wiki/CollectionUtilitiesExplained#iterables"> {@code
+ * Iterators}</a>.
+ *
+ * @author Kevin Bourrillion
+ * @author Jared Levy
+ */
+final class Iterators {
+  private Iterators() {}
+
+  /**
+   * Returns a view containing the first {@code limitSize} elements of {@code iterator}. If {@code
+   * iterator} contains fewer than {@code limitSize} elements, the returned view contains all of its
+   * elements. The returned iterator supports {@code remove()} if {@code iterator} does.
+   *
+   * @param iterator the iterator to limit
+   * @param limitSize the maximum number of elements in the returned iterator
+   * @throws IllegalArgumentException if {@code limitSize} is negative
+   */
+  static <T> Iterator<T> limit(final Iterator<T> iterator, final int limitSize) {
+    if (iterator == null) {
+      throw new NullPointerException();
+    }
+    if (limitSize < 0) {
+      throw new IllegalArgumentException("limit is negative");
+    }
+    return new Iterator<T>() {
+      private int count;
+
+      @Override
+      public boolean hasNext() {
+        return count < limitSize && iterator.hasNext();
+      }
+
+      @Override
+      public T next() {
+        if (!hasNext()) {
+          throw new NoSuchElementException();
+        }
+        count++;
+        return iterator.next();
+      }
+
+      @Override
+      public void remove() {
+        iterator.remove();
+      }
+    };
+  }
+}

--- a/core/src/main/java/org/kohsuke/stapler/export/Range.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/Range.java
@@ -1,7 +1,5 @@
 package org.kohsuke.stapler.export;
 
-import com.google.common.collect.Iterators;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyClassLoaderTearOff.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyClassLoaderTearOff.java
@@ -23,9 +23,6 @@
 
 package org.kohsuke.stapler.jelly;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import org.apache.commons.jelly.JellyContext;
 import org.apache.commons.jelly.JellyException;
 import org.apache.commons.jelly.TagLibrary;
@@ -35,6 +32,8 @@ import org.kohsuke.stapler.MetaClassLoader;
 
 import java.lang.ref.WeakReference;
 import java.net.URL;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * {@link MetaClassLoader} tear-off for Jelly support.
@@ -47,7 +46,7 @@ public class JellyClassLoaderTearOff {
     /**
      * See {@link JellyClassTearOff#scripts} for why we use {@link WeakReference} here.
      */
-    private volatile WeakReference<LoadingCache<String,TagLibrary>> taglibs;
+    private volatile WeakReference<ConcurrentMap<String,TagLibrary>> taglibs;
 
     static ExpressionFactory EXPRESSION_FACTORY = new JexlExpressionFactory();
 
@@ -56,46 +55,43 @@ public class JellyClassLoaderTearOff {
     }
 
     public TagLibrary getTagLibrary(String nsUri) {
-        LoadingCache<String,TagLibrary> m=null;
+        ConcurrentMap<String,TagLibrary> m=null;
         if(taglibs!=null)
             m = taglibs.get();
         if(m==null) {
-            m = CacheBuilder.newBuilder().build(new CacheLoader<String,TagLibrary>() {
-                public TagLibrary load(String nsUri) {
+            m = new ConcurrentHashMap<>();
+            taglibs = new WeakReference<>(m);
+        }
+        TagLibrary tl = m.computeIfAbsent(nsUri, key -> {
                     if(owner.parent!=null) {
                         // parent first
-                        TagLibrary tl = owner.parent.loadTearOff(JellyClassLoaderTearOff.class).getTagLibrary(nsUri);
-                        if(tl!=null)    return tl;
+                        TagLibrary taglib = owner.parent.loadTearOff(JellyClassLoaderTearOff.class).getTagLibrary(key);
+                        if(taglib!=null)    return taglib;
                     }
 
-                    String taglibBasePath = trimHeadSlash(nsUri);
+                    String taglibBasePath = trimHeadSlash(key);
                     try {
                         URL res = owner.loader.getResource(taglibBasePath +"/taglib");
                         if(res!=null)
-                        return new CustomTagLibrary(createContext(),owner.loader,nsUri,taglibBasePath);
+                        return new CustomTagLibrary(createContext(),owner.loader,key,taglibBasePath);
                     } catch (IllegalArgumentException e) {
                         // if taglibBasePath doesn't even look like an URL, getResource throws IllegalArgumentException.
                         // see http://old.nabble.com/bug-1.331-to26145963.html
                     }
 
                     // support URIs like "this:it" or "this:instance". Note that "this" URI itself is registered elsewhere
-                    if (nsUri.startsWith("this:"))
+                    if (key.startsWith("this:"))
                         try {
-                            return new ThisTagLibrary(EXPRESSION_FACTORY.createExpression(nsUri.substring(5)));
+                            return new ThisTagLibrary(EXPRESSION_FACTORY.createExpression(key.substring(5)));
                         } catch (JellyException e) {
-                            throw new IllegalArgumentException("Illegal expression in the URI: "+nsUri,e);
+                            throw new IllegalArgumentException("Illegal expression in the URI: "+key,e);
                         }
 
-                    if (nsUri.equals("jelly:stapler"))
+                    if (key.equals("jelly:stapler"))
                         return new StaplerTagLibrary();
 
                     return NO_SUCH_TAGLIBRARY;    // "not found" is also cached.
-                }
-            });
-            taglibs = new WeakReference<LoadingCache<String,TagLibrary>>(m);
-        }
-
-        TagLibrary tl = m.getUnchecked(nsUri);
+        });
         if (tl==NO_SUCH_TAGLIBRARY)     return null;
         return tl;
     }


### PR DESCRIPTION
### Motivation

This is a step along the way to possibly being able to shade the Guava dependency in Jenkins core as described in [jenkinsci/jenkins#5059 (comment)](https://github.com/jenkinsci/jenkins/pull/5059#issuecomment-763290152). I'm not yet sure that effort will be feasible, but this change fell out of that effort and seems to have independent value on its own. At best, this change might be helpful to the effort to modernize Guava in Jenkins core; at worst, this change slims down Stapler's dependency tree, which isn't bad in and of itself.

### Guava replacements

I dealt with the three remaining Guava dependencies in Stapler as follows:

- For usages of Guava's cache, I replaced them with usages of Caffeine or `Map#computeIfAbsent` if the needs were not exotic as suggested in [stapler/stapler#206 (comment)](https://github.com/stapler/stapler/pull/206#issuecomment-789169206). Mercifully, I didn't have to use Caffeine in the `jelly/` submodule, so I only had to introduce a Caffeine dependency for the `core/` Stapler module.
- For usages of `Iterators#limit` I simply inlined the corresponding Guava code (with the appropriate license).

### Shading Caffeine

The above having been done, I was concerned about exposing Caffeine as a new dependency. I'm not sure how stable its API is, and including it as a transitive dependency of Jenkins core implies that we are committing to supporting that API for all plugins in the future. It seems safer to avoid making that commitment unless it is truly necessary. So I tried to figure out how to shade the Caffeine dependency so that its usage remains internal to Stapler.

Unfortunately, using the Maven Shade Plugin in reactor builds (including both Stapler and Jenkins core) is a bit of a mess due to [MNG-5899](https://issues.apache.org/jira/browse/MNG-5899). In particular, the so-called "dependency reduced POM" doesn't quite work right in reactor builds. After spending quite a bit of time trying to understand how this works (or doesn't) and scratching my head, I decided to dispense with this unreliable "magic" and set `createDependencyReducedPom` to false. While this does have some downsides, the upside is that at least one doesn't have to deal with the pathological behavior of MNG-5899. With `createDependencyReducedPom` set to false, we produce a Stapler JAR with the shaded Caffeine classes included (good), without a drastically rewritten POM file (good in the sense that it avoids the risk of a regression), predictable behavior in reactor builds (good), and a dependency on Caffeine in the POM file (bad in the sense that the classes are already shaded so this is unnecessary). The main downside is the unnecessary dependency on Caffeine in the POM. That can be excluded on the consumer side, which is ugly, but it works.

Overall this is the simplest approach I could come up with that actually works. I tried a lot of other approaches that didn't actually work. I recognize this isn't necessarily the most elegant solution, but I don't think there really are any elegant ways of using the Maven Shade Plugin in reactor builds. If anyone can provide a proof of concept for a different way of shading Caffeine that actually works and is more elegant, I would be happy to go with that instead.

### Testing done

I ran the Jenkins core test suite against this change in jenkinsci/jenkins#5422. Note that there I am excluding the Caffeine dependency, which is declared in the POM file (because `createDependencyReducedPom` is false) but not actually needed (because the Caffeine classes are shaded in the core Stapler JAR file).