### PR TITLE
[JENKINS-65442] json api improve performance when encoding unicode characters

### DIFF
--- a/core/src/main/java/org/kohsuke/stapler/export/JSONDataWriter.java
+++ b/core/src/main/java/org/kohsuke/stapler/export/JSONDataWriter.java
@@ -109,7 +109,11 @@ class JSONDataWriter implements DataWriter {
                 // Control chars: strictly speaking, JSON spec expects only U+0000 through U+001F, but any char _may_ be escaped, so just do that for U+007F through U+009F too.
                 // Surrogate pair characters: https://docs.oracle.com/javase/6/docs/api/java/lang/Character.html#unicode
                 // JSON spec: https://tools.ietf.org/html/rfc8259#section-7
-                buf.append("\\u" + String.format("%04x", (int) c));
+                buf.append("\\u");
+                buf.append(HEX[(c >> 12) & 0xf]);
+                buf.append(HEX[(c >> 8) & 0xf]);
+                buf.append(HEX[(c >> 4) & 0xf]);
+                buf.append(HEX[c & 0xf]);
             } else {
                 switch (c) {
                     case '"':
@@ -186,6 +190,8 @@ class JSONDataWriter implements DataWriter {
     public void endObject() throws IOException {
         close('}');
     }
+
+    private static final char[] HEX = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};
 
     private static final char[] INDENT = new char[32];
     static {


### PR DESCRIPTION
Improve performance when encoding escape sequences.

String.format has to compile the pattern for each character which consumes a lot of CPU time when requesting larger json data.

Use bit shift and lookup to simplify conversion.

Doing a small comparison on my notebook reveals:
* oldStyle 522ms

```
  public StringBuilder oldStyle() {
    StringBuilder b = new StringBuilder();
    for(int i=0;i<0xffff;i++) {
      b.append("\\u" + String.format("%04x", i));
    }
    return b;
  }
```

* newStyle 13ms
```
  private static final char[] HEX = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'};

  public StringBuilder newStyle() {
    StringBuilder b = new StringBuilder();
    for(int i=0;i<0xffff;i++) {
      b.append("\\u");
      b.append(HEX[(i >> 12) & 0xf]);
      b.append(HEX[(i >> 8) & 0xf]);
      b.append(HEX[(i >> 4) & 0xf]);
      b.append(HEX[i & 0xf]);
    }
    return b;
  }
```