### PR TITLE
Migrate from Guava's cache to `ConcurrentHashMap` in `JellyClassLoaderTearOff`

### DIFF
--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyClassLoaderTearOff.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyClassLoaderTearOff.java
@@ -23,9 +23,6 @@
 
 package org.kohsuke.stapler.jelly;
 
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import org.apache.commons.jelly.JellyContext;
 import org.apache.commons.jelly.JellyException;
 import org.apache.commons.jelly.TagLibrary;
@@ -35,6 +32,8 @@ import org.kohsuke.stapler.MetaClassLoader;
 
 import java.lang.ref.WeakReference;
 import java.net.URL;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 /**
  * {@link MetaClassLoader} tear-off for Jelly support.
@@ -47,7 +46,7 @@ public class JellyClassLoaderTearOff {
     /**
      * See {@link JellyClassTearOff#scripts} for why we use {@link WeakReference} here.
      */
-    private volatile WeakReference<LoadingCache<String,TagLibrary>> taglibs;
+    private volatile WeakReference<ConcurrentMap<String,TagLibrary>> taglibs;
 
     static ExpressionFactory EXPRESSION_FACTORY = new JexlExpressionFactory();
 
@@ -56,46 +55,43 @@ public class JellyClassLoaderTearOff {
     }
 
     public TagLibrary getTagLibrary(String nsUri) {
-        LoadingCache<String,TagLibrary> m=null;
+        ConcurrentMap<String,TagLibrary> m=null;
         if(taglibs!=null)
             m = taglibs.get();
         if(m==null) {
-            m = CacheBuilder.newBuilder().build(new CacheLoader<String,TagLibrary>() {
-                public TagLibrary load(String nsUri) {
+            m = new ConcurrentHashMap<>();
+            taglibs = new WeakReference<>(m);
+        }
+        TagLibrary tl = m.computeIfAbsent(nsUri, key -> {
                     if(owner.parent!=null) {
                         // parent first
-                        TagLibrary tl = owner.parent.loadTearOff(JellyClassLoaderTearOff.class).getTagLibrary(nsUri);
-                        if(tl!=null)    return tl;
+                        TagLibrary taglib = owner.parent.loadTearOff(JellyClassLoaderTearOff.class).getTagLibrary(key);
+                        if(taglib!=null)    return taglib;
                     }
 
-                    String taglibBasePath = trimHeadSlash(nsUri);
+                    String taglibBasePath = trimHeadSlash(key);
                     try {
                         URL res = owner.loader.getResource(taglibBasePath +"/taglib");
                         if(res!=null)
-                        return new CustomTagLibrary(createContext(),owner.loader,nsUri,taglibBasePath);
+                        return new CustomTagLibrary(createContext(),owner.loader,key,taglibBasePath);
                     } catch (IllegalArgumentException e) {
                         // if taglibBasePath doesn't even look like an URL, getResource throws IllegalArgumentException.
                         // see http://old.nabble.com/bug-1.331-to26145963.html
                     }
 
                     // support URIs like "this:it" or "this:instance". Note that "this" URI itself is registered elsewhere
-                    if (nsUri.startsWith("this:"))
+                    if (key.startsWith("this:"))
                         try {
-                            return new ThisTagLibrary(EXPRESSION_FACTORY.createExpression(nsUri.substring(5)));
+                            return new ThisTagLibrary(EXPRESSION_FACTORY.createExpression(key.substring(5)));
                         } catch (JellyException e) {
-                            throw new IllegalArgumentException("Illegal expression in the URI: "+nsUri,e);
+                            throw new IllegalArgumentException("Illegal expression in the URI: "+key,e);
                         }
 
-                    if (nsUri.equals("jelly:stapler"))
+                    if (key.equals("jelly:stapler"))
                         return new StaplerTagLibrary();
 
                     return NO_SUCH_TAGLIBRARY;    // "not found" is also cached.
-                }
-            });
-            taglibs = new WeakReference<LoadingCache<String,TagLibrary>>(m);
-        }
-
-        TagLibrary tl = m.getUnchecked(nsUri);
+        });
         if (tl==NO_SUCH_TAGLIBRARY)     return null;
         return tl;
     }

--- a/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyClassLoaderTearOff.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/jelly/JellyClassLoaderTearOff.java
@@ -65,29 +65,29 @@ public class JellyClassLoaderTearOff {
         TagLibrary tl = m.computeIfAbsent(nsUri, key -> {
                     if(owner.parent!=null) {
                         // parent first
-                        TagLibrary taglib = owner.parent.loadTearOff(JellyClassLoaderTearOff.class).getTagLibrary(key);
+                        TagLibrary taglib = owner.parent.loadTearOff(JellyClassLoaderTearOff.class).getTagLibrary(nsUri);
                         if(taglib!=null)    return taglib;
                     }
 
-                    String taglibBasePath = trimHeadSlash(key);
+                    String taglibBasePath = trimHeadSlash(nsUri);
                     try {
                         URL res = owner.loader.getResource(taglibBasePath +"/taglib");
                         if(res!=null)
-                        return new CustomTagLibrary(createContext(),owner.loader,key,taglibBasePath);
+                        return new CustomTagLibrary(createContext(),owner.loader,nsUri,taglibBasePath);
                     } catch (IllegalArgumentException e) {
                         // if taglibBasePath doesn't even look like an URL, getResource throws IllegalArgumentException.
                         // see http://old.nabble.com/bug-1.331-to26145963.html
                     }
 
                     // support URIs like "this:it" or "this:instance". Note that "this" URI itself is registered elsewhere
-                    if (key.startsWith("this:"))
+                    if (nsUri.startsWith("this:"))
                         try {
-                            return new ThisTagLibrary(EXPRESSION_FACTORY.createExpression(key.substring(5)));
+                            return new ThisTagLibrary(EXPRESSION_FACTORY.createExpression(nsUri.substring(5)));
                         } catch (JellyException e) {
-                            throw new IllegalArgumentException("Illegal expression in the URI: "+key,e);
+                            throw new IllegalArgumentException("Illegal expression in the URI: "+nsUri,e);
                         }
 
-                    if (key.equals("jelly:stapler"))
+                    if (nsUri.equals("jelly:stapler"))
                         return new StaplerTagLibrary();
 
                     return NO_SUCH_TAGLIBRARY;    // "not found" is also cached.


### PR DESCRIPTION
A subset of #213 that is hopefully non-controversial and safe to land in the short term because it does not involve Caffeine or shading.