### PR TITLE
Bump `commons-discovery` from 0.4 to 0.5

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>commons-discovery</groupId>
       <artifactId>commons-discovery</artifactId>
-      <version>0.4</version>
+      <version>0.5</version>
     </dependency>
     <dependency>
       <groupId>commons-beanutils</groupId>


### PR DESCRIPTION
Jenkins core ships `commons-discovery` 0.4 in the WAR file, via Stapler. This version was released sometime in 2006. The latest version of `commons-discovery` is 0.5, released sometime around 2011 (see the [release notes](https://archive.apache.org/dist/commons/discovery/RELEASE-NOTES.txt)). `usage-in-plugins` shows that nothing uses this library in the Jenkins ecosystem beyond Stapler and Jenkins core itself in `CLICommand`. I'll run the main Jenkins test suite against the incremental produced from this PR to make sure it still passes.