### PR TITLE
Bump various dependencies to latest versions

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.7</version>
+      <version>2.8.0</version>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
@@ -59,12 +59,12 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-      <version>1.9</version>
+      <version>1.15</version>
     </dependency>
     <dependency>
       <groupId>org.jvnet.localizer</groupId>
       <artifactId>localizer</artifactId>
-      <version>1.7</version>
+      <version>1.31</version>
     </dependency>
     <dependency>
       <groupId>org.kohsuke.stapler</groupId>
@@ -84,7 +84,7 @@
        -->
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-all</artifactId>
-      <version>1.8.3</version>
+      <version>2.4.12</version>
       <optional>true</optional>
     </dependency>
     <dependency>
@@ -158,7 +158,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>test-annotations</artifactId>
-      <version>1.2</version>
+      <version>1.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/groovy/pom.xml
+++ b/groovy/pom.xml
@@ -19,7 +19,7 @@
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-all</artifactId>
-      <version>2.4.11</version>
+      <version>2.4.12</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/jruby/pom.xml
+++ b/jruby/pom.xml
@@ -86,7 +86,7 @@
     <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>test-annotations</artifactId>
-      <version>1.2</version>
+      <version>1.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Bumps various dependencies to the latest versions. Jenkins core was already using the new versions from this PR at runtime, and Jenkins core is the only real consumer of Stapler, so this PR is more or less a no-op.