### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+# https://docs.github.com/en/code-security/supply-chain-security/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    ignore:
+      # see https://github.com/jenkinsci/jenkins/pull/5112#issuecomment-744429487 and https://github.com/jenkinsci/jenkins/pull/5116#issuecomment-744526638
+      # it would be good to update it at some point, but requires significant testing
+      - dependency-name: "org.codehaus.groovy:groovy-all"
+      # Must remain within jetty 9.x until Java 8 support is removed, ignore jetty 10.x and jetty 11.x updates
+      - dependency-name: "org.eclipse.jetty:jetty-maven-plugin"
+        versions: ["10.x", "11.x"]


### PR DESCRIPTION
The equivalent of jenkinsci/jenkins#5108 for Stapler. Probably best merged after #223 to avoid an onslaught of Dependabot PRs. I've retained two entries from the Jenkins core ignore list because I believe they ought to be excluded from updates here for the same reasons.