### PR TITLE
Stop using repackaged ASM; upgrade ASM to 9.1

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -88,9 +88,9 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.kohsuke</groupId>
-      <artifactId>asm5</artifactId>
-      <version>5.0.1</version>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>9.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>

--- a/core/src/main/java/org/kohsuke/stapler/ClassDescriptor.java
+++ b/core/src/main/java/org/kohsuke/stapler/ClassDescriptor.java
@@ -25,11 +25,12 @@ package org.kohsuke.stapler;
 
 import org.apache.commons.io.IOUtils;
 import org.jvnet.tiger_types.Types;
-import org.kohsuke.asm5.ClassReader;
-import org.kohsuke.asm5.ClassVisitor;
-import org.kohsuke.asm5.Label;
-import org.kohsuke.asm5.MethodVisitor;
-import org.kohsuke.asm5.Type;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -54,7 +55,6 @@ import java.util.logging.Logger;
 
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.WARNING;
-import static org.kohsuke.asm5.Opcodes.ASM5;
 
 /**
  * Reflection information of a {@link Class}.
@@ -310,13 +310,13 @@ public final class ClassDescriptor {
 
             final TreeMap<Integer,String> localVars = new TreeMap<Integer,String>();
             ClassReader r = new ClassReader(clazz.openStream());
-            r.accept(new ClassVisitor(ASM5) {
+            r.accept(new ClassVisitor(Opcodes.ASM9) {
                 final String md = Type.getMethodDescriptor(m);
                 // First localVariable is "this" for non-static method
                 final int limit = (m.getModifiers() & Modifier.STATIC) != 0 ? 0 : 1;
                 @Override public MethodVisitor visitMethod(int access, String methodName, String desc, String signature, String[] exceptions) {
                     if (methodName.equals(m.getName()) && desc.equals(md))
-                        return new MethodVisitor(ASM5) {
+                        return new MethodVisitor(Opcodes.ASM9) {
                             @Override public void visitLocalVariable(String name, String desc, String signature, Label start, Label end, int index) {
                                 if (index >= limit)
                                     localVars.put(index, name);
@@ -350,11 +350,11 @@ public final class ClassDescriptor {
             InputStream is = clazz.openStream();
             try {
                 ClassReader r = new ClassReader(is);
-                r.accept(new ClassVisitor(ASM5) {
+                r.accept(new ClassVisitor(Opcodes.ASM9) {
                     final String md = getConstructorDescriptor(m);
                     public MethodVisitor visitMethod(int access, String methodName, String desc, String signature, String[] exceptions) {
                         if (methodName.equals("<init>") && desc.equals(md))
-                            return new MethodVisitor(ASM5) {
+                            return new MethodVisitor(Opcodes.ASM9) {
                                 @Override public void visitLocalVariable(String name, String desc, String signature, Label start, Label end, int index) {
                                     if (index>0)   // 0 is 'this'
                                         localVars.put(index, name);


### PR DESCRIPTION
In commit b3f1bcb41 Kohsuke adopted a repackaged ASM to avoid conflicts. While valid at the time, I don't think it makes much sense to continue to do this. First, it is a maintenance burden on the Jenkins project to release repackaged versions of ASM every time upstream releases a new version. Second, recent versions of Jenkins core already include the upstream version of ASM transitively via JNR:

```
+- com.github.jnr:jnr-posix:jar:3.1.5:compile
|  +- com.github.jnr:jnr-ffi:jar:2.2.2:compile
|  |  +- com.github.jnr:jffi:jar:1.3.1:compile
|  |  +- com.github.jnr:jffi:jar:native:1.3.1:runtime
|  |  +- org.ow2.asm:asm:jar:9.1:compile
|  |  +- org.ow2.asm:asm-commons:jar:9.1:compile
|  |  +- org.ow2.asm:asm-analysis:jar:9.1:compile
|  |  +- org.ow2.asm:asm-tree:jar:9.1:compile
|  |  +- org.ow2.asm:asm-util:jar:9.1:compile
```

So the upstream version of ASM has become part of the Jenkins API whether we like it or not. And so far this has not caused _too_ much trouble, other than breaking Token Macro (via Parboiled). That issue was resolved in jenkinsci/token-macro-plugin#70, which updated Token Macro's POM to read:

```xml
    <dependency>
      <groupId>org.parboiled</groupId>
      <artifactId>parboiled-java</artifactId>
      <version>1.3.1</version>
      <exclusions>
        <!-- asm is provided by Jenkins core -->
        <exclusion>
          <groupId>org.ow2.asm</groupId>
          <artifactId>*</artifactId>
        </exclusion>
      </exclusions>
    </dependency>
```

This clearly indicates that the ecosystem is expecting ASM to be bundled in core. Yet we still continue to bundle Kohsuke's version of ASM 5 in core via Stapler:

```
+- org.kohsuke.stapler:stapler:jar:1532.vfcf95addcb5f:compile
|  +- javax.annotation:javax.annotation-api:jar:1.2:compile
|  +- commons-discovery:commons-discovery:jar:0.4:compile
|  +- commons-logging:commons-logging:jar:1.2:provided
|  +- org.jvnet:tiger-types:jar:2.2:compile
|  \- org.kohsuke:asm5:jar:5.0.1:compile
```

This just bloats the WAR by bundling two versions of ASM. One of these two versions only exists to avoid exposing ASM in the public API, but it is already exposed so this is pointless.

In this change I am proposing to upgrade Stapler to the latest upstream version of ASM (the same version already shipped in Jenkins core transitively through JNR). I would then propose that we formalize the de facto bundling of ASM in Jenkins core by adding ASM as an explicit version in the Jenkins core BOM. This will allow us to manage upgrades carefully and avoid a repeat of the Token Macro incident in the future.