### PR TITLE
Remove ASM dep from `ClassDescriptor`

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -88,11 +88,6 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.kohsuke</groupId>
-      <artifactId>asm5</artifactId>
-      <version>5.0.1</version>
-    </dependency>
-    <dependency>
       <groupId>org.jenkins-ci</groupId>
       <artifactId>annotation-indexer</artifactId>
       <version>1.10</version>

--- a/core/src/main/java/org/kohsuke/stapler/CaptureParameterNameTransformation.java
+++ b/core/src/main/java/org/kohsuke/stapler/CaptureParameterNameTransformation.java
@@ -44,6 +44,7 @@ import java.util.Set;
  * Groovy AST transformation that capture necessary parameter names.
  *
  * @author Kohsuke Kawaguchi
+ * @see CapturedParameterNames
  */
 @MetaInfServices
 @GroovyASTTransformation

--- a/core/src/main/java/org/kohsuke/stapler/CapturedParameterNames.java
+++ b/core/src/main/java/org/kohsuke/stapler/CapturedParameterNames.java
@@ -32,6 +32,7 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * to do than generating the same files that the annotation processor does.
  *
  * @author Kohsuke Kawaguchi
+ * @see CaptureParameterNameTransformation
  */
 @Retention(RUNTIME)
 public @interface CapturedParameterNames {

--- a/core/src/main/java/org/kohsuke/stapler/ClassDescriptor.java
+++ b/core/src/main/java/org/kohsuke/stapler/ClassDescriptor.java
@@ -25,18 +25,15 @@ package org.kohsuke.stapler;
 
 import org.apache.commons.io.IOUtils;
 import org.jvnet.tiger_types.Types;
-import org.kohsuke.asm5.ClassReader;
-import org.kohsuke.asm5.ClassVisitor;
-import org.kohsuke.asm5.Label;
-import org.kohsuke.asm5.MethodVisitor;
-import org.kohsuke.asm5.Type;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Executable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Parameter;
 import java.lang.reflect.ParameterizedType;
 import java.net.URL;
 import java.util.ArrayList;
@@ -49,12 +46,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
-import java.util.TreeMap;
 import java.util.logging.Logger;
 
-import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.WARNING;
-import static org.kohsuke.asm5.Opcodes.ASM5;
+import java.util.stream.Stream;
 
 /**
  * Reflection information of a {@link Class}.
@@ -192,13 +187,9 @@ public final class ClassDescriptor {
         if(cpn!=null)   return cpn.value();
 
         // debug information, if present, is more trustworthy
-        try {
-            String[] n = ASM.loadParametersFromAsm(m);
-            if (n!=null)    return n;
-        } catch (LinkageError e) {
-            LOGGER.log(FINE, "Incompatible ASM", e);
-        } catch (IOException e) {
-            LOGGER.log(WARNING, "Failed to load a class file", e);
+        String[] n = loadParameterNamesFromReflection(m);
+        if (n != null) {
+            return n;
         }
 
         // otherwise check the .stapler file
@@ -229,17 +220,22 @@ public final class ClassDescriptor {
         if(cpn!=null)   return cpn.value();
 
         // debug information, if present, is more trustworthy
-        try {
-            String[] n = ASM.loadParametersFromAsm(m);
-            if (n!=null)    return n;
-        } catch (LinkageError e) {
-            LOGGER.log(FINE, "Incompatible ASM", e);
-        } catch (IOException e) {
-            LOGGER.log(WARNING, "Failed to load a class file", e);
+        String[] n = loadParameterNamesFromReflection(m);
+        if (n != null) {
+            return n;
         }
 
         // couldn't find it
         return EMPTY_ARRAY;
+    }
+
+    static String[] loadParameterNamesFromReflection(final Executable m) {
+        Parameter[] ps = m.getParameters();
+        if (Stream.of(ps).allMatch(Parameter::isNamePresent)) {
+            return Stream.of(ps).map(Parameter::getName).toArray(String[]::new);
+        } else {
+            return null;
+        }
     }
 
     /**
@@ -291,98 +287,6 @@ public final class ClassDescriptor {
         throw new NoStaplerConstructorException(
                 "Unable to find " + resourceName + ". " +
                         "Run 'mvn clean compile' once to run the annotation processor.");
-    }
-
-
-    /**
-     * Isolate the ASM dependency to its own class, as otherwise this seems to cause linkage error on the whole {@link ClassDescriptor}.
-     */
-    /*package*/ static class ASM {
-        /**
-         * Try to load parameter names from the debug info by using ASM.
-         */
-        private static String[] loadParametersFromAsm(final Method m) throws IOException {
-            final String[] paramNames = new String[m.getParameterTypes().length];
-            if (paramNames.length==0) return paramNames;
-            Class<?> c = m.getDeclaringClass();
-            URL clazz = c.getClassLoader().getResource(c.getName().replace('.', '/') + ".class");
-            if (clazz==null)    return null;
-
-            final TreeMap<Integer,String> localVars = new TreeMap<Integer,String>();
-            ClassReader r = new ClassReader(clazz.openStream());
-            r.accept(new ClassVisitor(ASM5) {
-                final String md = Type.getMethodDescriptor(m);
-                // First localVariable is "this" for non-static method
-                final int limit = (m.getModifiers() & Modifier.STATIC) != 0 ? 0 : 1;
-                @Override public MethodVisitor visitMethod(int access, String methodName, String desc, String signature, String[] exceptions) {
-                    if (methodName.equals(m.getName()) && desc.equals(md))
-                        return new MethodVisitor(ASM5) {
-                            @Override public void visitLocalVariable(String name, String desc, String signature, Label start, Label end, int index) {
-                                if (index >= limit)
-                                    localVars.put(index, name);
-                            }
-                        };
-                    else
-                        return null; // ignore this method
-                }
-            }, 0);
-
-            // Indexes may not be sequential, but first set of local variables are method params
-            int i = 0;
-            for (String s : localVars.values()) {
-                paramNames[i] = s;
-                if (++i == paramNames.length) return paramNames;
-            }
-            return null; // Not enough data found to fill array
-        }
-
-        /**
-         * Try to load parameter names from the debug info by using ASM.
-         */
-        private static String[] loadParametersFromAsm(final Constructor m) throws IOException {
-            final String[] paramNames = new String[m.getParameterTypes().length];
-            if (paramNames.length==0) return paramNames;
-            Class<?> c = m.getDeclaringClass();
-            URL clazz = c.getClassLoader().getResource(c.getName().replace('.', '/') + ".class");
-            if (clazz==null)    return null;
-
-            final TreeMap<Integer,String> localVars = new TreeMap<Integer,String>();
-            InputStream is = clazz.openStream();
-            try {
-                ClassReader r = new ClassReader(is);
-                r.accept(new ClassVisitor(ASM5) {
-                    final String md = getConstructorDescriptor(m);
-                    public MethodVisitor visitMethod(int access, String methodName, String desc, String signature, String[] exceptions) {
-                        if (methodName.equals("<init>") && desc.equals(md))
-                            return new MethodVisitor(ASM5) {
-                                @Override public void visitLocalVariable(String name, String desc, String signature, Label start, Label end, int index) {
-                                    if (index>0)   // 0 is 'this'
-                                        localVars.put(index, name);
-                                }
-                            };
-                        else
-                            return null; // ignore this method
-                    }
-                }, 0);
-            } finally {
-                is.close();
-            }
-
-            // Indexes may not be sequential, but first set of local variables are method params
-            int i = 0;
-            for (String s : localVars.values()) {
-                paramNames[i] = s;
-                if (++i == paramNames.length) return paramNames;
-            }
-            return null; // Not enough data found to fill array
-        }
-
-        private static String getConstructorDescriptor(Constructor c) {
-            StringBuilder buf = new StringBuilder("(");
-            for (Class p : c.getParameterTypes())
-                buf.append(Type.getDescriptor(p));
-            return buf.append(")V").toString();
-        }
     }
 
     final static class MethodMirror {

--- a/core/src/test/java/org/kohsuke/stapler/ClassDescriptorTest.java
+++ b/core/src/test/java/org/kohsuke/stapler/ClassDescriptorTest.java
@@ -3,19 +3,14 @@ package org.kohsuke.stapler;
 import java.io.IOException;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.servlet.ServletException;
 import static org.junit.Assert.*;
 import org.junit.Test;
-import org.kohsuke.stapler.verb.GET;
-import org.kohsuke.stapler.verb.POST;
 
 /**
  * @author Alan Harder
@@ -28,11 +23,7 @@ public class ClassDescriptorTest {
         assertEquals("[a, b, x]",Arrays.asList(names).toString());
     }
 
-    @Test public void loadParametersFromAsm() throws Exception {
-        // get private method that is being tested
-        Method lpfa = ClassDescriptor.ASM.class.getDeclaredMethod(
-                "loadParametersFromAsm", Method.class);
-        lpfa.setAccessible(true);
+    @Test public void loadParameterNamesFromReflection() throws Exception {
         // collect test cases
         Map<String,Method> testCases = new HashMap<String,Method>();
         for (Method m : ClassDescriptorTest.class.getDeclaredMethods())
@@ -48,8 +39,8 @@ public class ClassDescriptorTest {
         for (Map.Entry<String,String[]> entry : expected.entrySet()) {
             Method testMethod = testCases.get(entry.getKey());
             assertNotNull("Method missing for " + entry.getKey(), testMethod);
-            String[] result = (String[])lpfa.invoke(null, testMethod);
-            assertNotNull("Null result for " + entry.getKey());
+            String[] result = ClassDescriptor.loadParameterNamesFromReflection(testMethod);
+            assertNotNull("Null result for " + entry.getKey(), result);
             if (!Arrays.equals(entry.getValue(), result)) {
                 StringBuilder buf = new StringBuilder('|');
                 for (String s : result) buf.append(s).append('|');


### PR DESCRIPTION
See https://github.com/stapler/stapler/pull/225#pullrequestreview-667138790. Unfortunately it does not seem to work consistently—the test passes using my IDE’s compile-on-save mode, but not via `mvn clean test`. If I am following correctly, the `LocalVariableTable` always includes the parameter names, which are then redundantly included in a `MethodParameters` section only when compiled with debug information? Need to look into why this would be. I suspect the difference is between bytecode and runtime retention.
