### PR TITLE
Bump Mockito from 1.8.5 to 3.11.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -118,7 +118,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.kohsuke.metainf-services</groupId>

--- a/groovy/pom.xml
+++ b/groovy/pom.xml
@@ -47,7 +47,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
   </dependencies>
 </project>

--- a/jruby/pom.xml
+++ b/jruby/pom.xml
@@ -81,7 +81,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
+      <artifactId>mockito-core</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -110,8 +110,8 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.8.5</version>
+      <artifactId>mockito-core</artifactId>
+      <version>3.11.0</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Supersedes #241. Yes I hate Mockito too, but we're going to use it we might as well use the latest version.