### PR TITLE
Revert "Stop using repackaged ASM; upgrade ASM to 9.1"

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -88,9 +88,9 @@
       <optional>true</optional>
     </dependency>
     <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm</artifactId>
-      <version>9.1</version>
+      <groupId>org.kohsuke</groupId>
+      <artifactId>asm5</artifactId>
+      <version>5.0.1</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci</groupId>

--- a/core/src/main/java/org/kohsuke/stapler/ClassDescriptor.java
+++ b/core/src/main/java/org/kohsuke/stapler/ClassDescriptor.java
@@ -25,12 +25,11 @@ package org.kohsuke.stapler;
 
 import org.apache.commons.io.IOUtils;
 import org.jvnet.tiger_types.Types;
-import org.objectweb.asm.ClassReader;
-import org.objectweb.asm.ClassVisitor;
-import org.objectweb.asm.Label;
-import org.objectweb.asm.MethodVisitor;
-import org.objectweb.asm.Opcodes;
-import org.objectweb.asm.Type;
+import org.kohsuke.asm5.ClassReader;
+import org.kohsuke.asm5.ClassVisitor;
+import org.kohsuke.asm5.Label;
+import org.kohsuke.asm5.MethodVisitor;
+import org.kohsuke.asm5.Type;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -58,6 +57,7 @@ import java.util.stream.Stream;
 
 import static java.util.logging.Level.FINE;
 import static java.util.logging.Level.WARNING;
+import static org.kohsuke.asm5.Opcodes.ASM5;
 
 /**
  * Reflection information of a {@link Class}.
@@ -334,13 +334,13 @@ public final class ClassDescriptor {
 
             final TreeMap<Integer,String> localVars = new TreeMap<Integer,String>();
             ClassReader r = new ClassReader(clazz.openStream());
-            r.accept(new ClassVisitor(Opcodes.ASM9) {
+            r.accept(new ClassVisitor(ASM5) {
                 final String md = Type.getMethodDescriptor(m);
                 // First localVariable is "this" for non-static method
                 final int limit = (m.getModifiers() & Modifier.STATIC) != 0 ? 0 : 1;
                 @Override public MethodVisitor visitMethod(int access, String methodName, String desc, String signature, String[] exceptions) {
                     if (methodName.equals(m.getName()) && desc.equals(md))
-                        return new MethodVisitor(Opcodes.ASM9) {
+                        return new MethodVisitor(ASM5) {
                             @Override public void visitLocalVariable(String name, String desc, String signature, Label start, Label end, int index) {
                                 if (index >= limit)
                                     localVars.put(index, name);
@@ -374,11 +374,11 @@ public final class ClassDescriptor {
             InputStream is = clazz.openStream();
             try {
                 ClassReader r = new ClassReader(is);
-                r.accept(new ClassVisitor(Opcodes.ASM9) {
+                r.accept(new ClassVisitor(ASM5) {
                     final String md = getConstructorDescriptor(m);
                     public MethodVisitor visitMethod(int access, String methodName, String desc, String signature, String[] exceptions) {
                         if (methodName.equals("<init>") && desc.equals(md))
-                            return new MethodVisitor(Opcodes.ASM9) {
+                            return new MethodVisitor(ASM5) {
                                 @Override public void visitLocalVariable(String name, String desc, String signature, Label start, Label end, int index) {
                                     if (index>0)   // 0 is 'this'
                                         localVars.put(index, name);


### PR DESCRIPTION
Reverts stapler/stapler#225


ASM does not eveolve in a compatable way and we do not want a moving ASM exposed from Jenkins core.
