### PR TITLE
Ignore new versions of the Servlet API

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,5 @@ updates:
       # Must remain within Jetty 9.x until Java 8 support is removed; ignore Jetty 10.x and Jetty 11.x updates
       - dependency-name: "org.eclipse.jetty:*"
         versions: [">=10.0.0"]
+      # Provided by the Web container, so aligned with Jetty.
+      - dependency-name: "javax.servlet:javax.servlet-api"


### PR DESCRIPTION
As in https://github.com/jenkinsci/jenkins/pull/5226 we would like to suppress the likes of #239.
