### PR TITLE
Prevent 500 response when adjunct is empty

### DIFF
--- a/jelly/src/main/java/org/kohsuke/stapler/framework/adjunct/AdjunctManager.java
+++ b/jelly/src/main/java/org/kohsuke/stapler/framework/adjunct/AdjunctManager.java
@@ -156,6 +156,9 @@ public class AdjunctManager {
      */
     public void doDynamic(StaplerRequest req, StaplerResponse rsp) throws IOException, ServletException {
         String path = req.getRestOfPath();
+        if (path.length() == 0) {
+            throw HttpResponses.error(SC_NOT_FOUND,new IllegalArgumentException("No adjunct provided"));
+        }
         if (path.charAt(0)=='/') path = path.substring(1);
 
         if(!allowedResources.contains(path)) {


### PR DESCRIPTION
When you request http://localhost:8080/adjuncts/xxxx/lib/form/link/link.js it's working as expected but when you try with just /adjuncts/xxxx (without rest of path), the [path](https://github.com/stapler/stapler/blob/b7831000ac197901b65716a4d48eac2f0b100eb3/jelly/src/main/java/org/kohsuke/stapler/framework/adjunct/AdjunctManager.java#L159) is an empty String and thus, cannot call `charAt(0)` on it, leading to a 500 error.